### PR TITLE
Add CLI option to disable built-in slashing protection

### DIFF
--- a/docs/HowTo/Get-Started/Connect-To-Testnet.md
+++ b/docs/HowTo/Get-Started/Connect-To-Testnet.md
@@ -9,7 +9,7 @@ The following instructions describe the process to connect Teku to an Ethereum 2
 !!! important
 
     This example connects to the [Medalla testnet](https://github.com/goerli/medalla). If connecting
-    to a different testnet (for example Zinken), update the [`--network`](../../Reference/CLI/CLI-Syntax.md#network)
+    to a different testnet (for example Pyrmont), update the [`--network`](../../Reference/CLI/CLI-Syntax.md#network)
     option in the examples accordingly.
 
     Networks can experience stability issues and are prone to regular resets. We recommend you
@@ -81,7 +81,7 @@ requires 32 Goerli ETH per validator.
 ### Generate the validators and send the deposits
 
 Use the [Medalla Launchpad] to guide you through a step-by-step process to generate your keys and
-send the deposits. For the Zinken testnet use the [Zinken Launchpad] only.
+send the deposits.
 
 !!! note
     Remember the passwords that you used to create the validator keys, because you need it to
@@ -164,4 +164,3 @@ starting Teku.
 [Infura]: https://infura.io/
 [Launchpad]: https://medalla.launchpad.ethereum.org/
 [Medalla Launchpad]: https://medalla.launchpad.ethereum.org/
-[Zinken Launchpad]: https://zinken.launchpad.ethereum.org/

--- a/docs/HowTo/Prevent-Slashing.md
+++ b/docs/HowTo/Prevent-Slashing.md
@@ -10,6 +10,13 @@ blocks or attestations.
 You can import and export the slashing-protection file when migrating validator keys between
 validator clients.
 
+!!! note
+
+    If using an external signer that implements its own slashing protection
+    (for example [Web3Signer]), then you can disable Teku's built-in slashing protection using the
+    [`--validators-external-signer-slashing-protection-enabled`](../Reference/CLI/CLI-Syntax.md#validators-external-signer-slashing-protection-enabled)
+    command line option.
+
 ## Importing a slashing-protection file
 
 When importing the slashing-protection file, Teku imports the file to the
@@ -58,3 +65,4 @@ You can now import the slashing-protection file in a Teku, or non-Teku node.
 [data path directory when starting Teku]: ../Reference/CLI/CLI-Syntax.md#data-path
 [Minimal]: https://hackmd.io/@sproul/Bk0Y0qdGD#Format-2-Minimal
 [Complete]: https://hackmd.io/@sproul/Bk0Y0qdGD#Format-1-Complete
+[Web3Signer]: https://docs.web3signer.consensys.net/en/latest/

--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -1346,8 +1346,13 @@ Specify whether to use Teku's built-in [slashing protection] when using an exter
 
 Set this option to `false` if using the slashing protection implemented by an external signer.
 
-If using Teku to sign blocks and attestations, then Teku will always use its built-in slashing
-protection.
+!!! warning
+
+    Ensure the external signer has slashing protection enabled before disabling Teku
+    slashing protection, otherwise a validator may get slashed.
+
+Built-in slashing protection can only be disabled for validators using external signers. Validators
+using Teku to sign blocks and attestations always uses its built-in slashing protection.
 
 ### validators-external-signer-timeout
 

--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -1315,6 +1315,40 @@ When specifying file names, Teku expects that the files exist.
 
 List of validator public keys used by an external signer (for example, Web3Signer).
 
+### validators-external-signer-slashing-protection-enabled
+
+=== "Syntax"
+
+    ```bash
+    --validators-external-signer-slashing-protection-enabled[=<BOOLEAN>]
+    ```
+
+=== "Command Line"
+
+    ```bash
+    --validators-external-signer-slashing-protection-enabled=false
+    ```
+
+=== "Environment Variable"
+
+    ```bash
+    TEKU_VALIDATORS_EXTERNAL_SIGNER_SLASHING_PROTECTION_ENABLED=false
+    ```
+
+=== "Configuration File"
+
+    ```bash
+    validators-external-signer-slashing-protection-enabled: false
+    ```
+
+Specify whether to use Teku's built-in [slashing protection] when using an external signer such as
+[Web3Signer]. Defaults to `true`.
+
+Set this option to `false` if using the slashing protection implemented by an external signer.
+
+If using Teku to sign blocks and attestions then Teku will always use its built-in slashing
+protection.
+
 ### validators-external-signer-timeout
 
 === "Syntax"
@@ -1470,3 +1504,5 @@ or clear your weak subjectivity settings.
 <!-- links -->
 [Infura]: https://infura.io/
 [Teku metrics]: ../../HowTo/Monitor/Metrics.md
+[Web3Signer]: https://docs.web3signer.consensys.net/en/latest/
+[slashing protection]: ../../Concepts/Slashing-Protection.md

--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -1346,7 +1346,7 @@ Specify whether to use Teku's built-in [slashing protection] when using an exter
 
 Set this option to `false` if using the slashing protection implemented by an external signer.
 
-If using Teku to sign blocks and attestions then Teku will always use its built-in slashing
+If using Teku to sign blocks and attestations, then Teku will always use its built-in slashing
 protection.
 
 ### validators-external-signer-timeout

--- a/docs/Reference/CLI/Subcommands/Validator-Client.md
+++ b/docs/Reference/CLI/Subcommands/Validator-Client.md
@@ -628,7 +628,46 @@ When specifying file names, Teku expects that the files exist.
     validators-external-signer-public-keys: ["0xa99a...e44c","0xb89b...4a0b"]
     ```
 
-List of validator public keys used by an external signer (for example, Web3Signer).
+List of validator public keys used by an external signer (for example, [Web3Signer]).
+
+### validators-external-signer-slashing-protection-enabled
+
+=== "Syntax"
+
+    ```bash
+    teku vc --validators-external-signer-slashing-protection-enabled[=<BOOLEAN>]
+    ```
+
+=== "Command Line"
+
+    ```bash
+    teku vc --validators-external-signer-slashing-protection-enabled=false
+    ```
+
+=== "Environment Variable"
+
+    ```bash
+    TEKU_VALIDATORS_EXTERNAL_SIGNER_SLASHING_PROTECTION_ENABLED=false
+    ```
+
+=== "Configuration File"
+
+    ```bash
+    validators-external-signer-slashing-protection-enabled: false
+    ```
+
+Specify whether to use Teku's built-in [slashing protection] when using an external signer such as
+[Web3Signer]. Defaults to `true`.
+
+Set this option to `false` if using the slashing protection implemented by an external signer.
+
+!!! warning
+
+    Ensure the external signer has slashing protection enabled before disabling Teku
+    slashing protection, otherwise a validator may get slashed.
+
+Built-in slashing protection can only be disabled for validators using external signers. Validators
+using Teku to sign blocks and attestations always uses its built-in slashing protection.
 
 ### validators-external-signer-timeout
 
@@ -749,3 +788,5 @@ Attempts to lock all keystores in a directory if a directory is specified in
 
 <!-- links -->
 [environment variables or a configuration file]: ../CLI-Syntax.md#specifying-options
+[Web3Signer]: https://docs.web3signer.consensys.net/en/latest/
+[slashing protection]: ../../../Concepts/Slashing-Protection.md


### PR DESCRIPTION
Signed-off-by: Byron Gravenorst <byron.gravenorst@consensys.net>

## Pull Request Description

Add CLI option to disable built-in slashing protection for external signers.