### PR TITLE
Updates the Grafana dashboard link to a more up to date and comprehensive one

### DIFF
--- a/docs/HowTo/Monitor/Metrics.md
+++ b/docs/HowTo/Monitor/Metrics.md
@@ -94,7 +94,7 @@ the graph.
 
 Use
 [Grafana] to visualize the collected data. See the sample
-[Teku Grafana dashboard](https://grafana.com/grafana/dashboards/12199).
+[Teku Grafana dashboard](https://grafana.com/grafana/dashboards/13457).
 
 <!-- Links -->
 [Ethereum 2.0 specification]: https://github.com/ethereum/eth2.0-metrics/blob/master/metrics.md


### PR DESCRIPTION
## Pull Request Description
Update the link to the example Grafana dashboard to point to https://grafana.com/grafana/dashboards/13457 which is much more up to date, contains much more data and is generally prettier.

## Fixed Issue(s)
fixes https://github.com/ConsenSys/teku/issues/3436