### PR TITLE
Switch download link to point to Cloudsmith

### DIFF
--- a/docs/HowTo/Get-Started/Installation-Options/Install-Binaries.md
+++ b/docs/HowTo/Get-Started/Installation-Options/Install-Binaries.md
@@ -16,7 +16,7 @@ description: Install Teku from binary distribution
 
 ### Install from packaged binaries
 
-Download the [Teku packaged binaries](https://cloudsmith.io/~consensys/repos/teku/groups/).
+Download the [Teku packaged binaries](https://cloudsmith.io/~consensys/repos/teku/groups/?q=teku.*).
 
 Unpack the downloaded files and change into the `teku-<release>` directory.
 

--- a/docs/HowTo/Get-Started/Installation-Options/Install-Binaries.md
+++ b/docs/HowTo/Get-Started/Installation-Options/Install-Binaries.md
@@ -16,7 +16,7 @@ description: Install Teku from binary distribution
 
 ### Install from packaged binaries
 
-Download the [Teku packaged binaries](https://cloudsmith.io/~consensys/repos/teku/groups/?q=teku.*).
+Download the [Teku packaged binaries](https://github.com/ConsenSys/teku/releases).
 
 Unpack the downloaded files and change into the `teku-<release>` directory.
 

--- a/docs/HowTo/Get-Started/Installation-Options/Install-Binaries.md
+++ b/docs/HowTo/Get-Started/Installation-Options/Install-Binaries.md
@@ -16,7 +16,7 @@ description: Install Teku from binary distribution
 
 ### Install from packaged binaries
 
-Download the [Teku packaged binaries](https://bintray.com/consensys/pegasys-repo/teku#files).
+Download the [Teku packaged binaries](https://cloudsmith.io/~consensys/repos/teku/groups/).
 
 Unpack the downloaded files and change into the `teku-<release>` directory.
 


### PR DESCRIPTION
## Pull Request Description
Update the binary download link to point to GitHub releases page (each release has download links) instead of bintray. 

## Fixed Issue(s)
https://github.com/ConsenSys/teku/issues/3475