### PR TITLE
fix API doc url 1/2

### DIFF
--- a/docs/HowTo/Get-Started/Installation-Options/Build-From-Source.md
+++ b/docs/HowTo/Get-Started/Installation-Options/Build-From-Source.md
@@ -11,7 +11,7 @@ description: Build Teku from source
 
 ## Prerequisites
 
-* [Java JDK](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
+* [Java JDK](https://www.oracle.com/java/technologies/javase-downloads.html)
 
 !!!important
     Teku requires Java 11+; earlier versions are not supported.

--- a/docs/HowTo/Get-Started/Installation-Options/Install-Binaries.md
+++ b/docs/HowTo/Get-Started/Installation-Options/Install-Binaries.md
@@ -8,7 +8,7 @@ description: Install Teku from binary distribution
 
 ### Prerequisites
 
-* [Java JDK](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
+* [Java JDK](https://www.oracle.com/java/technologies/javase-downloads.html)
 
 !!! attention
 
@@ -45,7 +45,7 @@ Display Teku command line help to confirm installation:
 
     Teku requires Java 11+ to run. Earlier versions are not supported. You can install Java
     using `brew cask install adoptopenjdk`. Alternatively, you can manually install the 
-    [Java JDK](http://www.oracle.com/technetwork/java/javase/downloads/index.html).
+    [Java JDK](https://www.oracle.com/java/technologies/javase-downloads.html).
 
 ### Install (or upgrade) using Homebrew
 

--- a/docs/Reference/Rest_API/Rest.md
+++ b/docs/Reference/Rest_API/Rest.md
@@ -62,6 +62,6 @@ You can also use tools such as [Postman] or [cURL] to interact with Teku APIs.
         ```
 
 <!-- Links -->
-[REST API documentation]:https://consensys.github.io/teku/#stable/
+[REST API documentation]:https://consensys.github.io/teku/#stable
 [Postman]: https://www.postman.com/
 [cURL]: https://curl.haxx.se/


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/doc.common/wiki/Contributing-to-Documentation -->

## Pull Request Description
<!-- Please write a short description of your changes and any specific instructions to review them -->

fix API doc url by removing end slash and update submodule

The end slash was making the hash part of url not recognised as the version is extracted from it by only removing the # part.
See JS code on the doc web page (`getVersionFromURL` function).

Now you should land on the right version from the doc with https://consensys.github.io/teku/#stable

Another change will be made on the gh-pages branch to enable the stable version to be displayed when you directly go to https://consensys.github.io/teku/ see PR 2/2 ConsenSys/teku#3721

Additional change: updated Oracle JDK url as it's required for link checks to pass.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<github issue number> -->
<!-- Example: "fixes #42" -->

fixes #256 
This is PR 1/2 but there's no requirement to merge one before the other.
Part 2/2 is ConsenSys/teku#3721