### PR TITLE
Update CLI reference documentation

### DIFF
--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -697,8 +697,7 @@ default, Teku accepts access from `localhost` and `127.0.0.1`.
     metrics-categories: ["BEACON", "JVM", "PROCESS"]
     ```
 
-Categories for which to track metrics. Options are `JVM`, `PROCESS`, `BEACON`, `EVENTBUS`,
-`EXECUTOR`, `LIBP2P`, `NETWORK`, `STORAGE`, `STORAGE_HOT_DB`, `STORAGE_FINALIZED_DB`,
+Categories for which to track metrics. Options are `JVM`, `PROCESS`, `BEACON`, `DISCOVERY`, `EVENTBUS`, `EXECUTOR`, `LIBP2P`, `NETWORK`, `STORAGE`, `STORAGE_HOT_DB`, `STORAGE_FINALIZED_DB`,
 `REMOTE_VALIDATOR`, `VALIDATOR`, `VALIDATOR_PERFORMANCE`. All categories are enabled by default.
 
 ### metrics-interface

--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -1664,7 +1664,7 @@ using Teku to sign blocks and attestations always uses its built-in slashing pro
     validators-external-signer-timeout: 2000
     ```
 
-Timeout in milliseconds for requests to the external signer. Default is 1000.
+Timeout in milliseconds for requests to the external signer. Default is 5000.
 
 ### validators-external-signer-truststore
 

--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -546,7 +546,7 @@ The default Docker image location is `/root/.local/share/teku/logs`.
     log-file-name-pattern: "tekuL_%d{yyyy-MM-dd}.log"
     ```
 
-Filename pattern to apply when creating log files.
+Filename pattern to apply when creating log files. The default pattern is `teku_%d{yyyy-MM-dd}.log`
 
 ### log-include-events-enabled
 

--- a/docs/Reference/CLI/Subcommands/Migrate-Database.md
+++ b/docs/Reference/CLI/Subcommands/Migrate-Database.md
@@ -19,13 +19,13 @@ title: Database migration subcommand options
     --config-file=<FILE>
     ```
 
-=== "Command Line"
+=== "Example"
 
     ```bash
     --config-file=/home/me/me_node/config.yaml
     ```
 
-=== "Environment Variable"
+=== "Environment variable"
 
     ```bash
     TEKU_CONFIG_FILE=/home/me/me_node/config.yaml
@@ -42,19 +42,19 @@ The default is `none`.
     --data-base-path=<PATH>
     ```
 
-=== "Command Line"
+=== "Example"
 
     ```bash
     --data-base-path=/home/me/me_node
     ```
 
-=== "Environment Variable"
+=== "Environment variable"
 
     ```bash
     TEKU_DATA_BASE_PATH=/home/me/me_node
     ```
 
-=== "Configuration File"
+=== "Configuration file"
 
     ```bash
     data-base-path: "/home/me/me_node"
@@ -76,19 +76,19 @@ The default Docker image location is `/root/.local/share/teku`.
     --data-beacon-path=<PATH>
     ```
 
-=== "Command Line"
+=== "Example"
 
     ```bash
     --data-beacon-path=/home/me/me_node
     ```
 
-=== "Environment Variable"
+=== "Environment variable"
 
     ```bash
     TEKU_DATA_BEACON_PATH=/home/me/me_node
     ```
 
-=== "Configuration File"
+=== "Configuration file"
 
     ```bash
     data-beacon-path: "/home/me/me_node"
@@ -105,19 +105,19 @@ is specified using [`--data-base-path`](#data-base-path-data-path).
     --network=<NETWORK>
     ```
 
-=== "Command Line"
+=== "Example"
 
     ```bash
     --network=mainnet
     ```
 
-=== "Environment Variable"
+=== "Environment variable"
 
     ```bash
     TEKU_NETWORK=mainnet
     ```
 
-=== "Configuration File"
+=== "Configuration file"
 
     ```bash
     network: "mainnet"

--- a/docs/Reference/CLI/Subcommands/Slashing-Protection.md
+++ b/docs/Reference/CLI/Subcommands/Slashing-Protection.md
@@ -68,25 +68,25 @@ Path to the Teku data directory. The default directory is OS-dependent:
     teku slashing-protection import --data-validator-path=<PATH>
     ```
 
-=== "Command Line"
+=== "Example"
 
     ```bash
     teku slashing-protection import --data-validator-path=/home/me/me_validator
     ```
 
-=== "Environment Variable"
+=== "Environment variable"
 
     ```bash
     TEKU_DATA_VALIDATOR_PATH=/home/me/me_validator
     ```
 
-=== "Configuration File"
+=== "Configuration file"
 
     ```bash
     data-validator-path: "/home/me/me_validator"
     ```
 
-Path to the validator client data. Defaults to `<data-base-path>/validator` where `<data-base-path>` is specified using [`--data-base-path`](#data-base-path-data-path).
+Path to the validator client data. The default is `<data-base-path>/validator` where `<data-base-path>` is specified using [`--data-base-path`](#data-base-path-data-path).
 
 ### from
 
@@ -164,25 +164,25 @@ Path to the Teku data directory. The default directory is OS-dependent:
     teku slashing-protection export --data-validator-path=<PATH>
     ```
 
-=== "Command Line"
+=== "Example"
 
     ```bash
     teku slashing-protection export --data-validator-path=/home/me/me_validator
     ```
 
-=== "Environment Variable"
+=== "Environment variable"
 
     ```bash
     TEKU_DATA_VALIDATOR_PATH=/home/me/me_validator
     ```
 
-=== "Configuration File"
+=== "Configuration file"
 
     ```bash
     data-validator-path: "/home/me/me_validator"
     ```
 
-Path to the validator client data. Defaults to `<data-base-path>/validator` where `<data-base-path>` is specified using [`--data-base-path`](#data-base-path-data-path).
+Path to the validator client data. The default is `<data-base-path>/validator` where `<data-base-path>` is specified using [`--data-base-path`](#data-base-path-data-path).
 
 ### to
 

--- a/docs/Reference/CLI/Subcommands/Slashing-Protection.md
+++ b/docs/Reference/CLI/Subcommands/Slashing-Protection.md
@@ -60,6 +60,35 @@ The path to the Teku data directory. The default directory is OS dependent:
 * Unix/Linux: `$XDG_DATA_HOME/teku` if `$XDG_DATA_HOME` is set; otherwise `~/.local/share/teku`
 * Windows: `%localappdata%\teku`.
 
+### data-validator-path
+
+=== "Syntax"
+
+    ```bash
+    teku slashing-protection import --data-validator-path=<PATH>
+    ```
+
+=== "Command Line"
+
+    ```bash
+    teku slashing-protection import --data-validator-path=/home/me/me_validator
+    ```
+
+=== "Environment Variable"
+
+    ```bash
+    TEKU_DATA_VALIDATOR_PATH=/home/me/me_validator
+    ```
+
+=== "Configuration File"
+
+    ```bash
+    data-validator-path: "/home/me/me_validator"
+    ```
+
+Path to the validator client data. Defaults to `<data-base-path>/validator` where `<data-base-path>` is specified using [`--data-base-path`](#data-base-path-data-path).
+
+
 ### from
 
 === "Syntax"
@@ -127,6 +156,35 @@ The path to the Teku data directory. The default directory is OS dependent:
 * macOS: `~/Library/teku`
 * Unix/Linux: `$XDG_DATA_HOME/teku` if `$XDG_DATA_HOME` is set; otherwise `~/.local/share/teku`
 * Windows: `%localappdata%\teku`.
+
+### data-validator-path
+
+=== "Syntax"
+
+    ```bash
+    teku slashing-protection export --data-validator-path=<PATH>
+    ```
+
+=== "Command Line"
+
+    ```bash
+    teku slashing-protection export --data-validator-path=/home/me/me_validator
+    ```
+
+=== "Environment Variable"
+
+    ```bash
+    TEKU_DATA_VALIDATOR_PATH=/home/me/me_validator
+    ```
+
+=== "Configuration File"
+
+    ```bash
+    data-validator-path: "/home/me/me_validator"
+    ```
+
+Path to the validator client data. Defaults to `<data-base-path>/validator` where `<data-base-path>` is specified using [`--data-base-path`](#data-base-path-data-path).
+
 
 ### to
 

--- a/docs/Reference/CLI/Subcommands/Slashing-Protection.md
+++ b/docs/Reference/CLI/Subcommands/Slashing-Protection.md
@@ -88,7 +88,6 @@ The path to the Teku data directory. The default directory is OS dependent:
 
 Path to the validator client data. Defaults to `<data-base-path>/validator` where `<data-base-path>` is specified using [`--data-base-path`](#data-base-path-data-path).
 
-
 ### from
 
 === "Syntax"
@@ -184,7 +183,6 @@ The path to the Teku data directory. The default directory is OS dependent:
     ```
 
 Path to the validator client data. Defaults to `<data-base-path>/validator` where `<data-base-path>` is specified using [`--data-base-path`](#data-base-path-data-path).
-
 
 ### to
 

--- a/docs/Reference/CLI/Subcommands/Slashing-Protection.md
+++ b/docs/Reference/CLI/Subcommands/Slashing-Protection.md
@@ -40,7 +40,7 @@ Imports the slashing protection database using the [validator client interchange
 The path to the YAML configuration file.
 The default is `none`.
 
-### data-path
+### data-base-path, data-path
 
 === "Syntax"
 
@@ -108,7 +108,7 @@ Exports the slashing protection database in the [validator client interchange fo
 The path to the YAML configuration file.
 The default is `none`.
 
-### data-path
+### data-base-path, data-path
 
 === "Syntax"
 

--- a/docs/Reference/CLI/Subcommands/Slashing-Protection.md
+++ b/docs/Reference/CLI/Subcommands/Slashing-Protection.md
@@ -40,7 +40,7 @@ Imports the slashing protection database using the [validator client interchange
 Path to the YAML configuration file.
 The default is `none`.
 
-### data-base-path, data-path
+### data-path
 
 === "Syntax"
 
@@ -86,7 +86,12 @@ Path to the Teku data directory. The default directory is OS-dependent:
     data-validator-path: "/home/me/me_validator"
     ```
 
-Path to the validator client data. The default is `<data-base-path>/validator` where `<data-base-path>` is specified using [`--data-base-path`](#data-base-path-data-path).
+Path to the validator client data.
+The default is `<data-path>/validator` where `<data-path>` is specified using [`--data-path`](#data-path).
+
+!!! info
+
+    Teku imports slashing protection data into a `slashprotection` directory under the validator client data directory.
 
 ### from
 
@@ -136,7 +141,7 @@ Exports the slashing protection database in the [validator client interchange fo
 Path to the YAML configuration file.
 The default is `none`.
 
-### data-base-path, data-path
+### data-path
 
 === "Syntax"
 
@@ -182,7 +187,12 @@ Path to the Teku data directory. The default directory is OS-dependent:
     data-validator-path: "/home/me/me_validator"
     ```
 
-Path to the validator client data. The default is `<data-base-path>/validator` where `<data-base-path>` is specified using [`--data-base-path`](#data-base-path-data-path).
+Path to the validator client data.
+The default is `<data-path>/validator` where `<data-path>` is specified using [`--data-path`](#data-path).
+
+!!! info
+
+    Teku exports slashing protection data from the `slashprotection` directory under the validator client data directory.
 
 ### to
 
@@ -214,7 +224,7 @@ Repairs corrupted slashing-protection data files used by Teku.
     teku slashing-protection repair --checking-only-enabled[=<BOOLEAN>]
     ```
 
-=== "Command Line"
+=== "Example"
 
     ```bash
     teku slashing-protection repair --checking-only-enabled=false
@@ -231,7 +241,7 @@ You can specify which files are checked using [`--config-file`](#config-file_2),
     teku slashing-protection repair --config-file=<FILE>
     ```
 
-=== "Command Line"
+=== "Example"
 
     ```bash
     teku slashing-protection repair --config-file=/home/me/me_node/config.yaml
@@ -240,18 +250,18 @@ You can specify which files are checked using [`--config-file`](#config-file_2),
 Path to the YAML configuration file.
 The default is `none`.
 
-### data-base-path, data-path
+### data-path
 
 === "Syntax"
 
     ```bash
-    teku slashing-protection repair --data-base-path=<PATH>
+    teku slashing-protection repair --data-path=<PATH>
     ```
 
-=== "Command Line"
+=== "Example"
 
     ```bash
-    teku slashing-protection repair --data-base-path=/home/me/me_node
+    teku slashing-protection repair --data-path=/home/me/me_node
     ```
 
 Path to the Teku data directory. The default directory is OS-dependent:
@@ -270,14 +280,18 @@ The default Docker image location is `/root/.local/share/teku`.
     teku slashing-protection repair --data-validator-path=<PATH>
     ```
 
-=== "Command Line"
+=== "Example"
 
     ```bash
     teku slashing-protection repair --data-validator-path=/home/me/me_validator
     ```
 
-Path to validator client data. The default is `<data-base-path>/validator` where `<data-base-path>`
-is specified using [`--data-base-path`](#data-base-path-data-path).
+Path to validator client data.
+The default is `<data-path>/validator` where `<data-path>` is specified using [`--data-path`](#data-path).
+
+!!! info
+
+    The slashing protection data is stored in a `slashprotection` directory under the validator client data directory.
 
 ### network
 
@@ -287,7 +301,7 @@ is specified using [`--data-base-path`](#data-base-path-data-path).
     teku slashing-protection repair --network=<NETWORK>
     ```
 
-=== "Command Line"
+=== "Example"
 
     ```bash
     teku slashing-protection repair --network=mainnet
@@ -316,7 +330,7 @@ bootnodes, and the address of the Ethereum 1.0 deposit contract.
     teku slashing-protection repair --slot=<INTEGER>
     ```
 
-=== "Command Line"
+=== "Example"
 
     ```bash
     teku slashing-protection repair --slot=1028
@@ -337,7 +351,7 @@ slot, or after when the validators stopped performing duties.
     teku slashing-protection repair --update-all-enabled[=<BOOLEAN>]
     ```
 
-=== "Command Line"
+=== "Example"
 
     ```bash
     teku slashing-protection repair --update-all-enabled=false

--- a/docs/Reference/CLI/Subcommands/Validator-Client.md
+++ b/docs/Reference/CLI/Subcommands/Validator-Client.md
@@ -792,6 +792,63 @@ using Teku to sign blocks and attestations always uses its built-in slashing pro
 
 Timeout in milliseconds for requests to the external signer. Default is 5000.
 
+### validators-external-signer-truststore
+
+=== "Syntax"
+
+    ```bash
+    teku vc --validators-external-signer-truststore=<FILE>
+    ```
+
+=== "Command Line"
+
+    ```bash
+    teku vc --validators-external-signer-truststore=websigner_truststore.p12
+    ```
+
+=== "Environment Variable"
+
+    ```bash
+    TEKU_VALIDATORS_EXTERNAL_TRUSTSTORE=websigner_truststore.p12
+    ```
+
+=== "Configuration File"
+
+    ```bash
+    validators-external-signer-truststore: "websigner_truststore.p12"
+    ```
+
+PKCS12 or JKS keystore used to trust external signer's self-signed certificate or CA certificate
+which signs the external signer's certificate.
+
+### validators-external-signer-truststore-password-file
+
+=== "Syntax"
+
+    ```bash
+    teku vc --validators-external-signer-truststore-password-file=<FILE>
+    ```
+
+=== "Command Line"
+
+    ```bash
+    teku vc --validators-external-signer-truststore-password-file=truststore_pass.txt
+    ```
+
+=== "Environment Variable"
+
+    ```bash
+    TEKU_VALIDATORS_EXTERNAL_TRUSTSTORE_PASSWORD_FILE=truststore_pass.txt
+    ```
+
+=== "Configuration File"
+
+    ```bash
+    validators-external-signer-truststore-password-file: "truststore_pass.txt"
+    ```
+
+Password file used to decrypt the keystore.
+
 ### validators-external-signer-url
 
 === "Syntax"

--- a/docs/Reference/CLI/Subcommands/Validator-Client.md
+++ b/docs/Reference/CLI/Subcommands/Validator-Client.md
@@ -850,6 +850,41 @@ Graffiti to add when creating a block. Gets converted to bytes and padded to Byt
 
 The same graffiti is used for all validators started with this beacon node.
 
+### validators-graffiti-file
+
+=== "Syntax"
+
+    ```bash
+    teku vc --validators-graffiti-file=<FILE>
+    ```
+
+=== "Command Line"
+
+    ```bash
+    teku vc --validators-graffiti-file=/Users/me/mynode/graffiti.txt
+    ```
+
+=== "Environment Variable"
+
+    ```bash
+    TEKU_VALIDATORS_GRAFFITI_FILE=/Users/me/mynode/graffiti.txt
+    ```
+
+=== "Configuration File"
+
+    ```bash
+    validators-graffiti-file: "/Users/me/mynode/graffiti.txt"
+    ```
+
+File containing the validator graffiti to add when creating a block. The file contents is
+converted to `bytes` and padded to `Bytes32`. The same graffiti is used for all validators started
+with this beacon node.
+
+You can overwrite the file while Teku is running to update the graffiti.
+
+This option takes precedence over [`--validators-graffiti`](#validators-graffiti).
+
+
 ### validators-keystore-locking-enabled
 
 === "Syntax"

--- a/docs/Reference/CLI/Subcommands/Validator-Client.md
+++ b/docs/Reference/CLI/Subcommands/Validator-Client.md
@@ -601,6 +601,43 @@ When specifying file names, Teku expects that the files exist.
 
     The path separator is operating system dependent, and should be `;` in Windows rather than `:`.
 
+### validators-early-attestations-enabled
+
+=== "Syntax"
+
+    ```bash
+    teku vc --validators-early-attestations-enabled[=<BOOLEAN>]
+    ```
+
+=== "Command Line"
+
+    ```bash
+    teku vc --validators-early-attestations-enabled=false
+    ```
+
+=== "Environment Variable"
+
+    ```bash
+    TEKU_VALIDATORS_EARLY_ATTESTATIONS_ENABLED=false
+    ```
+
+=== "Configuration File"
+
+    ```bash
+    validators-early-attestations-enabled: false
+    ```
+
+Specify whether to use Teku's built-in early attestation production, which creates an
+attestation as soon as a block is received. Defaults to `true`.
+
+Set this option to `false` if running a validator client connected to a load balanced beacon node
+(including most hosted beacon nodes such as [Infura]), and validator effectiveness is poor.
+
+!!! note
+
+    Delaying attestation production increases the chances of generating a correct
+    attestation when using a load balanced beacon node, but it increases the risk of inclusion delays.
+
 ### validators-external-signer-public-keys
 
 === "Syntax"

--- a/docs/Reference/CLI/Subcommands/Validator-Client.md
+++ b/docs/Reference/CLI/Subcommands/Validator-Client.md
@@ -609,26 +609,26 @@ When specifying file names, Teku expects that the files exist.
     teku vc --validators-early-attestations-enabled[=<BOOLEAN>]
     ```
 
-=== "Command Line"
+=== "Example"
 
     ```bash
     teku vc --validators-early-attestations-enabled=false
     ```
 
-=== "Environment Variable"
+=== "Environment variable"
 
     ```bash
     TEKU_VALIDATORS_EARLY_ATTESTATIONS_ENABLED=false
     ```
 
-=== "Configuration File"
+=== "Configuration file"
 
     ```bash
     validators-early-attestations-enabled: false
     ```
 
 Specify whether to use Teku's built-in early attestation production, which creates an
-attestation as soon as a block is received. Defaults to `true`.
+attestation once a block is received. The default is `true`.
 
 Set this option to `false` if running a validator client connected to a load balanced beacon node
 (including most hosted beacon nodes such as [Infura]), and validator effectiveness is poor.
@@ -646,19 +646,19 @@ Set this option to `false` if running a validator client connected to a load bal
     teku vc --validators-external-signer-keystore=<FILE>
     ```
 
-=== "Command Line"
+=== "Example"
 
     ```bash
     teku vc --validators-external-signer-keystore=teku_client_keystore.p12
     ```
 
-=== "Environment Variable"
+=== "Environment variable"
 
     ```bash
     TEKU_VALIDATORS_EXTERNAL_KEYSTORE=teku_client_keystore.p12
     ```
 
-=== "Configuration File"
+=== "Configuration file"
 
     ```bash
     validators-external-signer-keystore: "teku_client_keystore.p12"
@@ -677,19 +677,19 @@ Use the PKCS12 keystore type if connecting to Web3Signer.
     teku vc --validators-external-signer-keystore-password-file=<FILE>
     ```
 
-=== "Command Line"
+=== "Example"
 
     ```bash
     teku vc --validators-external-signer-keystore-password-file=keystore_pass.txt
     ```
 
-=== "Environment Variable"
+=== "Environment variable"
 
     ```bash
     TEKU_VALIDATORS_EXTERNAL_KEYSTORE_PASSWORD_FILE=keystore_pass.txt
     ```
 
-=== "Configuration File"
+=== "Configuration file"
 
     ```bash
     validators-external-signer-keystore-password-file: "keystore_pass.txt"
@@ -915,25 +915,25 @@ The same graffiti is used for all validators started with this beacon node.
     teku vc --validators-graffiti-file=<FILE>
     ```
 
-=== "Command Line"
+=== "Example"
 
     ```bash
     teku vc --validators-graffiti-file=/Users/me/mynode/graffiti.txt
     ```
 
-=== "Environment Variable"
+=== "Environment variable"
 
     ```bash
     TEKU_VALIDATORS_GRAFFITI_FILE=/Users/me/mynode/graffiti.txt
     ```
 
-=== "Configuration File"
+=== "Configuration file"
 
     ```bash
     validators-graffiti-file: "/Users/me/mynode/graffiti.txt"
     ```
 
-File containing the validator graffiti to add when creating a block. The file contents is
+File containing the validator graffiti to add when creating a block. The file content is
 converted to `bytes` and padded to `Bytes32`. The same graffiti is used for all validators started
 with this beacon node.
 

--- a/docs/Reference/CLI/Subcommands/Validator-Client.md
+++ b/docs/Reference/CLI/Subcommands/Validator-Client.md
@@ -847,7 +847,7 @@ which signs the external signer's certificate.
     validators-external-signer-truststore-password-file: "truststore_pass.txt"
     ```
 
-Password file used to decrypt the keystore.
+Password file used to decrypt the [keystore](#validators-external-signer-truststore).
 
 ### validators-external-signer-url
 

--- a/docs/Reference/CLI/Subcommands/Validator-Client.md
+++ b/docs/Reference/CLI/Subcommands/Validator-Client.md
@@ -941,7 +941,6 @@ You can overwrite the file while Teku is running to update the graffiti.
 
 This option takes precedence over [`--validators-graffiti`](#validators-graffiti).
 
-
 ### validators-keystore-locking-enabled
 
 === "Syntax"

--- a/docs/Reference/CLI/Subcommands/Validator-Client.md
+++ b/docs/Reference/CLI/Subcommands/Validator-Client.md
@@ -455,8 +455,7 @@ default, Teku accepts access from `localhost` and `127.0.0.1`.
     metrics-categories: ["BEACON", "JVM", "PROCESS"]
     ```
 
-Categories for which to track metrics. Options are `JVM`, `PROCESS`, `BEACON`, `EVENTBUS`,
-`EXECUTOR`, `LIBP2P`, `NETWORK`, `STORAGE`, `STORAGE_HOT_DB`, `STORAGE_FINALIZED_DB`,
+Categories for which to track metrics. Options are `JVM`, `PROCESS`, `BEACON`, `DISCOVERY`, `EVENTBUS`, `EXECUTOR`, `LIBP2P`, `NETWORK`, `STORAGE`, `STORAGE_HOT_DB`, `STORAGE_FINALIZED_DB`,
 `REMOTE_VALIDATOR`, `VALIDATOR`, `VALIDATOR_PERFORMANCE`. All categories are enabled by default.
 
 ### metrics-interface

--- a/docs/Reference/CLI/Subcommands/Validator-Client.md
+++ b/docs/Reference/CLI/Subcommands/Validator-Client.md
@@ -304,7 +304,7 @@ The default Docker image location is `/root/.local/share/teku/logs`.
     log-file-name-pattern: "tekuL_%d{yyyy-MM-dd}.log"
     ```
 
-Filename pattern to apply when creating log files.
+Filename pattern to apply when creating log files. The default pattern is `teku_%d{yyyy-MM-dd}.log`
 
 ### log-include-events-enabled
 

--- a/docs/Reference/CLI/Subcommands/Validator-Client.md
+++ b/docs/Reference/CLI/Subcommands/Validator-Client.md
@@ -361,7 +361,7 @@ validators and attestations. Defaults to `true`.
     log-include-validator-duties-enabled: true
     ```
 
-Specify whether to log details of validator event duties. Defaults to `false`.
+Specify whether to log details of validator event duties. Defaults to `true`.
 
 !!! note
     Logs could become noisy when running many validators.

--- a/docs/Reference/CLI/Subcommands/Validator-Client.md
+++ b/docs/Reference/CLI/Subcommands/Validator-Client.md
@@ -484,7 +484,7 @@ Categories for which to track metrics. Options are `JVM`, `PROCESS`, `BEACON`, `
     metrics-interface: "192.168.10.101"
     ```
 
-Host on which Prometheus accesses Teku metrics. The default is `0.0.0.0`.
+Host on which Prometheus accesses Teku metrics. The default is `127.0.0.1`.
 
 ### metrics-port
 

--- a/docs/Reference/CLI/Subcommands/Validator-Client.md
+++ b/docs/Reference/CLI/Subcommands/Validator-Client.md
@@ -694,7 +694,7 @@ using Teku to sign blocks and attestations always uses its built-in slashing pro
     validators-external-signer-timeout: 2000
     ```
 
-Timeout in milliseconds for requests to the external signer. Default is 1000.
+Timeout in milliseconds for requests to the external signer. Default is 5000.
 
 ### validators-external-signer-url
 

--- a/docs/Reference/CLI/Subcommands/Validator-Client.md
+++ b/docs/Reference/CLI/Subcommands/Validator-Client.md
@@ -638,6 +638,65 @@ Set this option to `false` if running a validator client connected to a load bal
     Delaying attestation production increases the chances of generating a correct
     attestation when using a load balanced beacon node, but it increases the risk of inclusion delays.
 
+### validators-external-signer-keystore
+
+=== "Syntax"
+
+    ```bash
+    teku vc --validators-external-signer-keystore=<FILE>
+    ```
+
+=== "Command Line"
+
+    ```bash
+    teku vc --validators-external-signer-keystore=teku_client_keystore.p12
+    ```
+
+=== "Environment Variable"
+
+    ```bash
+    TEKU_VALIDATORS_EXTERNAL_KEYSTORE=teku_client_keystore.p12
+    ```
+
+=== "Configuration File"
+
+    ```bash
+    validators-external-signer-keystore: "teku_client_keystore.p12"
+    ```
+
+The keystore that Teku presents to the external signer for TLS authentication. Teku can use
+PKCS12 or JKS keystore types.
+
+Use the PKCS12 keystore type if connecting to Web3Signer.
+
+### validators-external-signer-keystore-password-file
+
+=== "Syntax"
+
+    ```bash
+    teku vc --validators-external-signer-keystore-password-file=<FILE>
+    ```
+
+=== "Command Line"
+
+    ```bash
+    teku vc --validators-external-signer-keystore-password-file=keystore_pass.txt
+    ```
+
+=== "Environment Variable"
+
+    ```bash
+    TEKU_VALIDATORS_EXTERNAL_KEYSTORE_PASSWORD_FILE=keystore_pass.txt
+    ```
+
+=== "Configuration File"
+
+    ```bash
+    validators-external-signer-keystore-password-file: "keystore_pass.txt"
+    ```
+
+Password file used to decrypt the keystore.
+
 ### validators-external-signer-public-keys
 
 === "Syntax"

--- a/docs/Reference/CLI/Subcommands/Voluntary-Exit.md
+++ b/docs/Reference/CLI/Subcommands/Voluntary-Exit.md
@@ -224,7 +224,6 @@ Use the PKCS12 keystore type if connecting to Web3Signer.
 
 Password file used to decrypt the keystore.
 
-
 ### validators-external-signer-public-keys
 
 === "Syntax"

--- a/docs/Reference/CLI/Subcommands/Voluntary-Exit.md
+++ b/docs/Reference/CLI/Subcommands/Voluntary-Exit.md
@@ -173,19 +173,19 @@ When specifying file names, Teku expects that the files exist.
     teku voluntary-exit --validators-external-signer-keystore=<FILE>
     ```
 
-=== "Command Line"
+=== "Example"
 
     ```bash
     teku voluntary-exit --validators-external-signer-keystore=teku_client_keystore.p12
     ```
 
-=== "Environment Variable"
+=== "Environment variable"
 
     ```bash
     TEKU_VALIDATORS_EXTERNAL_KEYSTORE=teku_client_keystore.p12
     ```
 
-=== "Configuration File"
+=== "Configuration file"
 
     ```bash
     validators-external-signer-keystore: "teku_client_keystore.p12"
@@ -204,19 +204,19 @@ Use the PKCS12 keystore type if connecting to Web3Signer.
     teku voluntary-exit --validators-external-signer-keystore-password-file=<FILE>
     ```
 
-=== "Command Line"
+=== "Example"
 
     ```bash
     teku voluntary-exit --validators-external-signer-keystore-password-file=keystore_pass.txt
     ```
 
-=== "Environment Variable"
+=== "Environment variable"
 
     ```bash
     TEKU_VALIDATORS_EXTERNAL_KEYSTORE_PASSWORD_FILE=keystore_pass.txt
     ```
 
-=== "Configuration File"
+=== "Configuration file"
 
     ```bash
     validators-external-signer-keystore-password-file: "keystore_pass.txt"

--- a/docs/Reference/CLI/Subcommands/Voluntary-Exit.md
+++ b/docs/Reference/CLI/Subcommands/Voluntary-Exit.md
@@ -281,6 +281,62 @@ List of public keys of validators that you wish to voluntarily exit when using a
 
 Timeout in milliseconds for requests to the external signer. Default is 5000.
 
+### validators-external-signer-truststore
+
+=== "Syntax"
+
+    ```bash
+    teku voluntary-exit --validators-external-signer-truststore=<FILE>
+    ```
+
+=== "Command Line"
+
+    ```bash
+    teku voluntary-exit --validators-external-signer-truststore=websigner_truststore.p12
+    ```
+
+=== "Environment Variable"
+
+    ```bash
+    TEKU_VALIDATORS_EXTERNAL_TRUSTSTORE=websigner_truststore.p12
+    ```
+
+=== "Configuration File"
+
+    ```bash
+    validators-external-signer-truststore: "websigner_truststore.p12"
+    ```
+
+PKCS12 or JKS keystore used to trust external signer's self-signed certificate or CA certificate
+which signs the external signer's certificate.
+
+### validators-external-signer-truststore-password-file
+
+=== "Syntax"
+
+    ```bash
+    teku voluntary-exit --validators-external-signer-truststore-password-file=<FILE>
+    ```
+
+=== "Command Line"
+
+    ```bash
+    teku voluntary-exit --validators-external-signer-truststore-password-file=truststore_pass.txt
+    ```
+
+=== "Environment Variable"
+
+    ```bash
+    TEKU_VALIDATORS_EXTERNAL_TRUSTSTORE_PASSWORD_FILE=truststore_pass.txt
+    ```
+
+=== "Configuration File"
+
+    ```bash
+    validators-external-signer-truststore-password-file: "truststore_pass.txt"
+    ```
+
+Password file used to decrypt the keystore.
 ### validators-external-signer-url
 
 === "Syntax"

--- a/docs/Reference/CLI/Subcommands/Voluntary-Exit.md
+++ b/docs/Reference/CLI/Subcommands/Voluntary-Exit.md
@@ -220,7 +220,7 @@ List of public keys of validators that you wish to voluntarily exit when using a
     validators-external-signer-timeout: 2000
     ```
 
-Timeout in milliseconds for requests to the external signer. Default is 1000.
+Timeout in milliseconds for requests to the external signer. Default is 5000.
 
 ### validators-external-signer-url
 

--- a/docs/Reference/CLI/Subcommands/Voluntary-Exit.md
+++ b/docs/Reference/CLI/Subcommands/Voluntary-Exit.md
@@ -337,6 +337,7 @@ which signs the external signer's certificate.
     ```
 
 Password file used to decrypt the keystore.
+
 ### validators-external-signer-url
 
 === "Syntax"

--- a/docs/Reference/CLI/Subcommands/Voluntary-Exit.md
+++ b/docs/Reference/CLI/Subcommands/Voluntary-Exit.md
@@ -165,6 +165,66 @@ When specifying file names, Teku expects that the files exist.
 
     The path separator is operating system dependent, and should be `;` in Windows rather than `:`.
 
+### validators-external-signer-keystore
+
+=== "Syntax"
+
+    ```bash
+    teku voluntary-exit --validators-external-signer-keystore=<FILE>
+    ```
+
+=== "Command Line"
+
+    ```bash
+    teku voluntary-exit --validators-external-signer-keystore=teku_client_keystore.p12
+    ```
+
+=== "Environment Variable"
+
+    ```bash
+    TEKU_VALIDATORS_EXTERNAL_KEYSTORE=teku_client_keystore.p12
+    ```
+
+=== "Configuration File"
+
+    ```bash
+    validators-external-signer-keystore: "teku_client_keystore.p12"
+    ```
+
+The keystore that Teku presents to the external signer for TLS authentication. Teku can use
+PKCS12 or JKS keystore types.
+
+Use the PKCS12 keystore type if connecting to Web3Signer.
+
+### validators-external-signer-keystore-password-file
+
+=== "Syntax"
+
+    ```bash
+    teku voluntary-exit --validators-external-signer-keystore-password-file=<FILE>
+    ```
+
+=== "Command Line"
+
+    ```bash
+    teku voluntary-exit --validators-external-signer-keystore-password-file=keystore_pass.txt
+    ```
+
+=== "Environment Variable"
+
+    ```bash
+    TEKU_VALIDATORS_EXTERNAL_KEYSTORE_PASSWORD_FILE=keystore_pass.txt
+    ```
+
+=== "Configuration File"
+
+    ```bash
+    validators-external-signer-keystore-password-file: "keystore_pass.txt"
+    ```
+
+Password file used to decrypt the keystore.
+
+
 ### validators-external-signer-public-keys
 
 === "Syntax"


### PR DESCRIPTION
 <!--
## Pull request checklist

### Before creating the pull request

Make sure that:

- [x] you have read the [contribution guidelines](https://github.com/ConsenSys/doc.common/wiki/Contributing-to-Documentation).
- [x] you have [tested your changes locally](https://github.com/ConsenSys/doc.common/wiki/MkDocs-And-Custom-Markdown-Guide#preview-documentation-site-locally) before submitting them to the community for review.

### After creating your pull request and tests finished

Make sure that:

- [ ] you have fixed all the issues raised by the tests if any.
- [ ] you have verified the rendering of your changes on
  [ReadTheDocs.org PR preview](https://github.com/ConsenSys/doc.common/wiki/MkDocs-And-Custom-Markdown-Guide#preview-the-doc-site-for-your-pr-on-readthedocscom)
  and updated the testing link (see [Testing](#testing)).
-->
## PR Description

This PR addresses issue #301, which identified a few instances where the [CLI reference documentation pages](https://docs.teku.consensys.net/en/latest/Reference/CLI) are out-of-sync with the latest Teku implementation.

## Issue fixed

This PR fixes #301. Specifically, the following changes have been made to pages in the CLI reference documentation section.

**[Teku command page - `teku`](https://docs.teku.consensys.net/en/latest/Reference/CLI/CLI-Syntax/)**
- [x] `metrics-categories` missing `DISCOVERY` category (i.e. `TekuMetricCategory.DISCOVERY`)
- [x] `validators-external-signer-timeout` defaults to 5000 in code, but docs state 1000
- [x] `log-file-name-pattern` documentation should perhaps show the default pattern used `teku_%d{yyyy-MM-dd}.log`

**[Slashing-protection subcommand - `teku slashing-protection`](https://docs.teku.consensys.net/en/latest/Reference/CLI/Subcommands/Slashing-Protection/)**
- [x] Documentation for `import` and `export` subcommand should probably mention `data-base-path` as an alias to `data-path`, to be consistent with this is displayed in other commands/subcommands. 
- [x] `data-validator-path` option not present in the documentation

**[Validator-client subcommand - `teku validator-client`](https://docs.teku.consensys.net/en/latest/Reference/CLI/Subcommands/Validator-Client/)**
- [x] `log-include-validator-duties-enabled` default to `true` in code but the docs report the default as `false` 
- [x] `metrics-categories` missing `DISCOVERY` category
- [x] `metrics-interface` defaults to “127.0.0.1” in code, but docs note “0.0.0.0” 
- [x] `validators-early-attestations-enabled` option not present in the documentation
- [x] `validators-external-signer-timeout` defaults to 5000 in code, but docs state 1000
- [x] `validators-external-signer-keystore` and `validators-external-signer-keystore-password-file` options not present in the documentation
- [x] `validators-external-signer-truststore` and `validators-external-signer-truststore-password-file` options not present in the documentation
- [x] `validators-graffiti-file` option not present in the documentation
- [x] `log-file-name-pattern` documentation should show the default pattern used `teku_%d{yyyy-MM-dd}.log`

**[Voluntary-exit subcommand -- `teku voluntary-exit`](https://docs.teku.consensys.net/en/latest/Reference/CLI/Subcommands/Voluntary-Exit/)**
- [x] `validators-external-signer-timeout` defaults to 5000 in code, but docs state 1000
- [x] `validators-external-signer-keystore` and `validators-external-signer-keystore-password-file` options not present in the documentation
- [x] `validators-external-signer-truststore` and `validators-external-signer-truststore-password-file` options not present in the documentation

## Impacted parts <!-- check as many boxes as needed -->

### For content changes

- [x] Doc content
- [ ] Doc pages organisation
