### PR TITLE
Fix incorrect path for Slashing DB

### DIFF
--- a/docs/Concepts/Slashing-Protection.md
+++ b/docs/Concepts/Slashing-Protection.md
@@ -19,7 +19,7 @@ option.
     by multiple nodes.
 
 To protect validators from slashable offenses, Teku stores a record of the most recently signed
-blocks for each validator in the `<data-path>/validators/slashprotection/` directory. One
+blocks for each validator in the `<data-path>/validator/slashprotection/` directory. One
 [YAML file is stored per validator] in the format `<validator-pubkey>.yml` (with no `0x` prefix).
 
 !!! note


### PR DESCRIPTION
## Pull request checklist

Use the following list to make sure your PR fits the Teku doc quality standard.

### Before creating the pull request

Make sure that:

- [x] you have read the [contribution guidelines](https://github.com/ConsenSys/doc.common/wiki/Contributing-to-Documentation).
- [x] you have [tested your changes locally](https://github.com/ConsenSys/doc.common/wiki/MkDocs-And-Custom-Markdown-Guide#preview-documentation-site-locally) before submitting them to the community for review.

### After creating your pull request and tests finished

Make sure that:

- [x] you have fixed all the issues raised by the tests, if any.
- [x] you have verified the rendering of your changes on
  [ReadTheDocs.org PR preview](https://github.com/ConsenSys/doc.common/wiki/MkDocs-And-Custom-Markdown-Guide#preview-the-doc-site-for-your-pr-on-readthedocscom)
  and updated the testing link (see [Testing](#testing)).

## Describe the change

<!-- A clear and concise description of what this PR changes in the documentation. -->
The slashing database lives in `validator/` _singular_, not plural like the docs currently have. I almost didn't import my slashing DB correctly because of this! [See this code block.](https://github.com/ConsenSys/teku/blob/master/infrastructure/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/layout/SeparateServiceDataDirLayout.java#L21)


## Issue fixed

<!-- Except for minor changes (typos, commas) it's required to have a Github issue linked to your
pull request.

Use the following to make Github close the issue automatically when merging the PR:
fixes #{your issue number}
If multiple issues are involved, use one line for each issue.

If you don't want to close the issue, use:
see #{your issue number} -->

## Impacted parts <!-- check as many boxes as needed -->

### For content changes

- [x] Doc content
- [ ] Doc pages organisation

### For tools changes

- [ ] CircleCI workflow
- [ ] Build and QA tools (lint, vale,…)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] ReadTheDocs configuration
- [ ] GitHub integration

## Testing

<!-- Steps to follow to review and test your changes.
Add links to preview the pages changes here.
Link format is https://pegasys-teku--{your PR number}.org.readthedocs.build/en/{your PR number}/
Where {your PR number} must be replaced by the number of this PR, for instance 123
-->

## Screenshots / recording

<!-- If it helps to understand your change, you may link an annotated screenshot or a small demo video. -->
