### PR TITLE
Rename Eth1.0 and Eth2.0

### DIFF
--- a/docs/HowTo/Find-and-Connect/Improve-Connectivity.md
+++ b/docs/HowTo/Find-and-Connect/Improve-Connectivity.md
@@ -4,7 +4,7 @@ title: How to improve P2P connectivity
 
 # Improving P2P connectivity
 
-Ethereum 2.0 relies on peer-to-peer (P2P) networking. By having a good peer count you
+The consensus layer relies on peer-to-peer (P2P) networking. By having a good peer count you
 increase the performance and health of your node. When a Teku node starts up, it looks for
 participants on the P2P network by listening for incoming connections, and finds and connects to
 peers.

--- a/docs/HowTo/Get-Started/Connect/Connect-To-Mainnet.md
+++ b/docs/HowTo/Get-Started/Connect/Connect-To-Mainnet.md
@@ -6,8 +6,8 @@ description: How to connect to Mainnet
 
 !!! note
 
-    The execution layer was formerly called "Eth 1.0". The consensus layer was formerly called "Eth 2.0".
-    For more information on the name change, refer to the [Ethereum Foundation update](https://blog.ethereum.org/2022/01/24/the-great-eth2-renaming/).
+    This documentation has been updated in line with the name changes [recommended by the Ethereum Foundation](https://blog.ethereum.org/2022/01/24/the-great-eth2-renaming/).
+    The execution layer is sometimes known as "Ethereum 1.0". The consensus layer is sometimes known as "Ethereum 2.0".
 
 The following instructions provide the steps run validators on the consensus layer Mainnet. You can
 also use Teku to run a [beacon node only].
@@ -15,7 +15,7 @@ also use Teku to run a [beacon node only].
 !!! warning
 
     If staking funds on the network, the funds are locked until transfers are enabled in a
-    future phase of the consensus layer network.
+    future upgrade of the consensus layer.
 
 Use the [validator checklist] as a guide to secure your validator keys and hardware.
 
@@ -23,19 +23,19 @@ Use the [validator checklist] as a guide to secure your validator keys and hardw
 
 * Install the latest stable version of Teku using a [binary distribution](../Installation-Options/Install-Binaries.md),
     or with [Docker](../Installation-Options/Run-Docker-Image.md).
-* If running validators, install any execution layer client (for example [Hyperledger Besu]), or access a
+* If running validators, install any execution client (for example [Hyperledger Besu]), or access a
     cloud-based service such as [Infura].
 
 ## Run validators on Mainnet
 
-Consensus layer validators need to access an execution layer client to onboard new validators.
-New validators make deposits into the execution client, and existing consensus layer validators must
-process the deposits to allow the new validators to join the consensus layer.
+Consensus layer validators need to access an execution client to onboard new validators.
+New validators make deposits on the execution layer, and existing consensus layer validators must
+process the deposits to allow the new validators to join.
 
 Deposits are made into a deposit contract on the execution layer Mainnet. The deposit contract address
 is `0x00000000219ab540356cbb839cbe05303d7705fa`.
 
-The steps to run an consensus layer validator on Mainnet are:
+The steps to run a consensus layer validator on Mainnet are:
 
 1. If running your own execution client, [sync the execution network containing
     the deposit contract](#sync-the-execution-layer-network).
@@ -58,7 +58,7 @@ The steps to run an consensus layer validator on Mainnet are:
 
 This step is only required if running your own execution client.
 
-This example uses Besu to connect to execution, but any client can be used.
+This example uses Besu as an execution client, but any client can be used.
 Configure Besu to [connect to Mainnet] and expose the RPC-HTTP APIs.
 
 !!! example
@@ -91,7 +91,7 @@ Syncing is complete when the head slot reaches the current slot.
     Ensure your Ethereum account has enough ETH to cover the required deposit amount (32 ETH) plus
     gas.
 
-Use the [Ethereum Skating Launchpad] to guide you through a step-by-step process to generate your keys and
+Use the [Ethereum Staking Launchpad] to guide you through a step-by-step process to generate your keys and
 send the deposits.
 
 !!! note

--- a/docs/HowTo/Get-Started/Connect/Connect-To-Mainnet.md
+++ b/docs/HowTo/Get-Started/Connect/Connect-To-Mainnet.md
@@ -7,7 +7,7 @@ description: How to connect to Mainnet
 !!! note
 
     This documentation has been updated in line with the name changes [recommended by the Ethereum Foundation](https://blog.ethereum.org/2022/01/24/the-great-eth2-renaming/).
-    The execution layer is sometimes known as "Ethereum 1.0". The consensus layer is sometimes known as "Ethereum 2.0".
+    The execution layer is sometimes known as "Ethereum 1.0." The consensus layer is sometimes known as "Ethereum 2.0."
 
 The following instructions provide the steps run validators on the consensus layer Mainnet. You can
 also use Teku to run a [beacon node only].

--- a/docs/HowTo/Get-Started/Connect/Connect-To-Mainnet.md
+++ b/docs/HowTo/Get-Started/Connect/Connect-To-Mainnet.md
@@ -4,39 +4,44 @@ description: How to connect to Mainnet
 
 # Connect to Mainnet
 
-The following instructions provide the steps run validators on the Ethereum 2.0 Mainnet. You can
+!!! note
+
+    The execution layer was formerly called "Eth 1.0". The consensus layer was formerly called "Eth 2.0".
+    For more information on the name change, refer to the [Ethereum Foundation update](https://blog.ethereum.org/2022/01/24/the-great-eth2-renaming/).
+
+The following instructions provide the steps run validators on the consensus layer Mainnet. You can
 also use Teku to run a [beacon node only].
 
 !!! warning
 
     If staking funds on the network, the funds are locked until transfers are enabled in a
-    future phase of the Ethereum 2.0 network.
+    future phase of the consensus layer network.
 
-Use the [ETH2 staking checklist] as a guide to secure your validator keys and hardware.
+Use the [validator checklist] as a guide to secure your validator keys and hardware.
 
 **Prerequisites**:
 
 * Install the latest stable version of Teku using a [binary distribution](../Installation-Options/Install-Binaries.md),
     or with [Docker](../Installation-Options/Run-Docker-Image.md).
-* If running validators, install any Ethereum 1.0 client (for example [Hyperledger Besu]), or access a
+* If running validators, install any execution layer client (for example [Hyperledger Besu]), or access a
     cloud-based service such as [Infura].
 
 ## Run validators on Mainnet
 
-Ethereum 2.0 validators need to access an Ethereum 1.0 client to onboard new validators.
-New validators make deposits into Ethereum 1.0, and existing Ethereum 2.0 validators must
-process the deposits to allow the new validators to join Ethereum 2.0.
+Consensus layer validators need to access an execution layer client to onboard new validators.
+New validators make deposits into the execution client, and existing consensus layer validators must
+process the deposits to allow the new validators to join the consensus layer.
 
-Deposits are made into a deposit contract on the Ethereum 1.0 Mainnet. The deposit contract address
+Deposits are made into a deposit contract on the execution layer Mainnet. The deposit contract address
 is `0x00000000219ab540356cbb839cbe05303d7705fa`.
 
-The steps to run an Ethereum 2.0 validator on Mainnet are:
+The steps to run an consensus layer validator on Mainnet are:
 
-1. If running your own Ethereum 1.0 client, [sync the Ethereum 1.0 network containing
-    the deposit contract](#sync-the-ethereum-10-network).
+1. If running your own execution client, [sync the execution network containing
+    the deposit contract](#sync-the-execution-layer-network).
 
     !!! note
-        This step is only required if running your own Ethereum 1.0 client such as Besu.
+        This step is only required if running your own execution client such as Besu.
         If using a cloud-based service such as Infura, proceed to
         [sync the beacon node](#sync-the-beacon-node).
 
@@ -49,11 +54,11 @@ The steps to run an Ethereum 2.0 validator on Mainnet are:
 
 1. [Start Teku with the validator keys](#start-the-validator).
 
-### Sync the Ethereum 1.0 network
+### Sync the execution layer network
 
-This step is only required if running your own Ethereum 1.0 client.
+This step is only required if running your own execution client.
 
-This example uses Besu to connect to Ethereum 1.0, but any client can be used.
+This example uses Besu to connect to execution, but any client can be used.
 Configure Besu to [connect to Mainnet] and expose the RPC-HTTP APIs.
 
 !!! example
@@ -86,7 +91,7 @@ Syncing is complete when the head slot reaches the current slot.
     Ensure your Ethereum account has enough ETH to cover the required deposit amount (32 ETH) plus
     gas.
 
-Use the [Mainnet Launchpad] to guide you through a step-by-step process to generate your keys and
+Use the [Ethereum Skating Launchpad] to guide you through a step-by-step process to generate your keys and
 send the deposits.
 
 !!! note
@@ -184,8 +189,8 @@ to specify the directory to load multiple keys and passwords from.
 
 <!-- links -->
 [connect to Mainnet]: https://besu.hyperledger.org/en/latest/HowTo/Get-Started/Starting-node/#run-a-node-on-ethereum-mainnet
-[Mainnet Launchpad]: https://launchpad.ethereum.org/
-[ETH2 staking checklist]: https://launchpad.ethereum.org/checklist
+[Ethereum Staking Launchpad]: https://launchpad.ethereum.org/
+[validator checklist]: https://launchpad.ethereum.org/checklist
 [running beacon]: #sync-the-beacon-node
 [single process]: #run-the-validator-and-beacon-node-as-a-single-process
 [separate machine]: #run-the-validator-on-a-separate-machine

--- a/docs/HowTo/Get-Started/Connect/Connect-To-Testnet.md
+++ b/docs/HowTo/Get-Started/Connect/Connect-To-Testnet.md
@@ -4,7 +4,12 @@ description: How to connect to a testnet
 
 # Connect to a testnet
 
-The following instructions describe the process to connect Teku to an Ethereum 2.0 testnet.
+!!! note
+
+    The execution layer was formerly called "Eth 1.0". The consensus layer was formerly called "Eth 2.0".
+    For more information on the name change, refer to the [Ethereum Foundation update](https://blog.ethereum.org/2022/01/24/the-great-eth2-renaming/).
+
+The following instructions describe the process to connect Teku to a consensus layer testnet.
 
 !!! important
 
@@ -19,7 +24,7 @@ The following instructions describe the process to connect Teku to an Ethereum 2
 
 * Install the latest stable version of Teku using a [binary distribution](../Installation-Options/Install-Binaries.md),
     or with [Docker](../Installation-Options/Run-Docker-Image.md).
-* If running validators, install any Ethereum 1.0 client (for example [Hyperledger Besu]), or access a
+* If running validators, install any execution layer client (for example [Hyperledger Besu]), or access a
     cloud-based service such as [Infura].
 
 Teku allows you run a [beacon chain client only], or you can [run the beacon chain client
@@ -27,23 +32,23 @@ with validators] on a public testnet.
 
 ## Run validators on a testnet
 
-Ethereum 2.0 validators need to access an Ethereum 1.0 client to onboard new validators.
-Validators make deposits into Ethereum 1.0, and existing Ethereum 2.0 validators must
-process the deposits to allow the validators to join Ethereum 2.0.
+Consensus layer validators need to access an execution client to onboard new validators.
+Validators make deposits into execution layer, and existing consensus layer validators must
+process the deposits to allow the validators to join the consensus layer.
 
-Deposits are made into a deposit contract on the Goerli Ethereum 1.0 testnet.
+Deposits are made into a deposit contract on the Goerli execution layer testnet.
 
-The steps to run an Ethereum 2.0 validator on a testnet are:
+The steps to run a consensus layer validator on a testnet are:
 
-1. If using a local Ethereum 1.0 client, [sync the Ethereum 1.0 network containing
-    the deposit contract](#sync-the-ethereum-10-network).
+1. If using a local execution client, [sync the Ethereum 1.0 network containing
+    the deposit contract](#sync-the-execution-layer-network).
 
     !!! note
-        This step is only required if using a local Ethereum 1.0 client such as Besu.
+        This step is only required if using a local execution client such as Besu.
         If using a cloud-based service such as Infura, proceed to
         [fund your deposit account](#load-the-deposit-account-with-eth).
 
-1. [Fund the Ethereum 1.0 deposit account](#load-the-deposit-account-with-eth).
+1. [Fund the execution layer deposit account](#load-the-deposit-account-with-eth).
 
 1. [Generate the validator keys and send the deposit to the deposit
     contract](#generate-the-validators-and-send-the-deposits).
@@ -52,11 +57,11 @@ The steps to run an Ethereum 2.0 validator on a testnet are:
 
 1. [Start Teku with the validator keys](#start-the-validator).
 
-### Sync the Ethereum 1.0 network
+### Sync the execution layer network
 
-This step is only required if using a local Ethereum 1.0 client.
+This step is only required if using a local execution layer client.
 
-This example uses Besu to connect to Ethereum 1.0, but any client can be used.
+This example uses Besu to connect to execution layer, but any client can be used.
 Configure Besu to [connect to Goerli] and expose the RPC-HTTP APIs.
 
 !!! example
@@ -68,7 +73,7 @@ Configure Besu to [connect to Goerli] and expose the RPC-HTTP APIs.
 
 ### Load the deposit account with ETH
 
-You need an Ethereum 1.0 Goerli testnet account that contains the amount of
+You need an execution layer Goerli testnet account that contains the amount of
 Goerli ETH (plus gas) required to activate the validator. The `prater` testnet
 requires 32 Goerli ETH per validator.
 

--- a/docs/HowTo/Get-Started/Connect/Connect-To-Testnet.md
+++ b/docs/HowTo/Get-Started/Connect/Connect-To-Testnet.md
@@ -7,7 +7,7 @@ description: How to connect to a testnet
 !!! note
 
     This documentation has been updated in line with the name changes [recommended by the Ethereum Foundation](https://blog.ethereum.org/2022/01/24/the-great-eth2-renaming/).
-    The execution layer is sometimes known as "Ethereum 1.0". The consensus layer is sometimes known as "Ethereum 2.0".
+    The execution layer is sometimes known as "Ethereum 1.0." The consensus layer is sometimes known as "Ethereum 2.0."
 
 The following instructions describe the process to connect Teku to a consensus layer testnet.
 

--- a/docs/HowTo/Get-Started/Connect/Connect-To-Testnet.md
+++ b/docs/HowTo/Get-Started/Connect/Connect-To-Testnet.md
@@ -6,8 +6,8 @@ description: How to connect to a testnet
 
 !!! note
 
-    The execution layer was formerly called "Eth 1.0". The consensus layer was formerly called "Eth 2.0".
-    For more information on the name change, refer to the [Ethereum Foundation update](https://blog.ethereum.org/2022/01/24/the-great-eth2-renaming/).
+    This documentation has been updated in line with the name changes [recommended by the Ethereum Foundation](https://blog.ethereum.org/2022/01/24/the-great-eth2-renaming/).
+    The execution layer is sometimes known as "Ethereum 1.0". The consensus layer is sometimes known as "Ethereum 2.0".
 
 The following instructions describe the process to connect Teku to a consensus layer testnet.
 
@@ -24,7 +24,7 @@ The following instructions describe the process to connect Teku to a consensus l
 
 * Install the latest stable version of Teku using a [binary distribution](../Installation-Options/Install-Binaries.md),
     or with [Docker](../Installation-Options/Run-Docker-Image.md).
-* If running validators, install any execution layer client (for example [Hyperledger Besu]), or access a
+* If running validators, install any execution client (for example [Hyperledger Besu]), or access a
     cloud-based service such as [Infura].
 
 Teku allows you run a [beacon chain client only], or you can [run the beacon chain client
@@ -33,14 +33,14 @@ with validators] on a public testnet.
 ## Run validators on a testnet
 
 Consensus layer validators need to access an execution client to onboard new validators.
-Validators make deposits into execution layer, and existing consensus layer validators must
-process the deposits to allow the validators to join the consensus layer.
+New validators make deposits on the execution layer testnet, and existing consensus layer validators
+must process the deposits to allow the validators to join.
 
 Deposits are made into a deposit contract on the Goerli execution layer testnet.
 
 The steps to run a consensus layer validator on a testnet are:
 
-1. If using a local execution client, [sync the Ethereum 1.0 network containing
+1. If using a local execution client, [sync the execution layer network containing
     the deposit contract](#sync-the-execution-layer-network).
 
     !!! note
@@ -59,9 +59,9 @@ The steps to run a consensus layer validator on a testnet are:
 
 ### Sync the execution layer network
 
-This step is only required if using a local execution layer client.
+This step is only required if running your own execution client.
 
-This example uses Besu to connect to execution layer, but any client can be used.
+This example uses Besu as an execution client, but any client can be used.
 Configure Besu to [connect to Goerli] and expose the RPC-HTTP APIs.
 
 !!! example

--- a/docs/HowTo/Get-Started/Installation-Options/Run-Docker-Image.md
+++ b/docs/HowTo/Get-Started/Installation-Options/Run-Docker-Image.md
@@ -85,7 +85,7 @@ The following `docker-compose.yml` file starts a [Hyperledger Besu] and Teku nod
 !!! note
 
     The example assumes the validators specified in [`--validator-keys`](../../../Reference/CLI/CLI-Syntax.md#validator-keys) has already
-    been registered in the Ethereum 1.0 deposit contract.
+    been registered in the execution layer deposit contract.
 
 Run `docker-compose up` in the directory containing the `docker-compose.yml` file
 to start the container.

--- a/docs/HowTo/Get-Started/Installation-Options/Run-Docker-Image.md
+++ b/docs/HowTo/Get-Started/Installation-Options/Run-Docker-Image.md
@@ -84,8 +84,8 @@ The following `docker-compose.yml` file starts a [Hyperledger Besu] and Teku nod
 
 !!! note
 
-    The example assumes the validators specified in [`--validator-keys`](../../../Reference/CLI/CLI-Syntax.md#validator-keys) has already
-    been registered in the execution layer deposit contract.
+    The example assumes the validators specified in [`--validator-keys`](../../../Reference/CLI/CLI-Syntax.md#validator-keys) have already
+    been registered in the deposit contract.
 
 Run `docker-compose up` in the directory containing the `docker-compose.yml` file
 to start the container.

--- a/docs/HowTo/Monitor/Metrics.md
+++ b/docs/HowTo/Monitor/Metrics.md
@@ -93,7 +93,7 @@ To configure Prometheus and run with Teku:
         The available metrics are prefixed with the category type specified using
         [`--metrics-categories`](../../Reference/CLI/CLI-Syntax.md#metrics-categories).
 
-        The [Ethereum 2.0 specification] lists the minimum set of metrics implemented by
+        The [beacon chain metrics] lists the minimum set of metrics implemented by
         beacon chain clients.
 
 Click the **Graph** tab to view the data as a time-based graph. The query string displays below
@@ -106,5 +106,5 @@ Use
 [Teku Grafana dashboard](https://grafana.com/grafana/dashboards/13457).
 
 <!-- Links -->
-[Ethereum 2.0 specification]: https://github.com/ethereum/eth2.0-metrics/blob/master/metrics.md
+[beacon chain metrics]: https://github.com/ethereum/beacon-metrics/blob/master/metrics.md
 [Grafana]: https://grafana.com/docs/grafana/latest/guides/getting_started/

--- a/docs/HowTo/Voluntary-Exit.md
+++ b/docs/HowTo/Voluntary-Exit.md
@@ -21,7 +21,7 @@ exited to avoid penalties.
 !!! danger
 
     Even if a validator has successfully exited, it cannot withdraw its funds until withdrawals are
-    enabled in a future phase of the Ethereum 2.0 network.
+    enabled in a future phase of the consensus layer network.
 
 ## Initiate a voluntary exit
 

--- a/docs/HowTo/Voluntary-Exit.md
+++ b/docs/HowTo/Voluntary-Exit.md
@@ -21,7 +21,7 @@ exited to avoid penalties.
 !!! danger
 
     Even if a validator has successfully exited, it cannot withdraw its funds until withdrawals are
-    enabled in a future phase of the consensus layer network.
+    enabled in a future upgrade of the consensus layer.
 
 ## Initiate a voluntary exit
 

--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -288,7 +288,7 @@ is specified using [`--data-base-path`](#data-base-path-data-path).
     eth1-deposit-contract-address: "0x77f7bED277449F51505a4C54550B074030d989bC"
     ```
 
-Execution layer (formerly Ethereum 1.0) address of the deposit contract. Only required when creating a custom network.
+The address of the deposit contract. Only required when creating a custom network.
 
 The deposit contract address can also be defined in:
 
@@ -353,7 +353,7 @@ receiving warnings that the ETH1 node is unavailable.
     eth1-endpoint: ["http://localhost:8545","https://mainnet.infura.io/v3/d0e21ccd0b1e4eef7784422eabc51111"]
     ```
 
-Comma-separated list of JSON-RPC URLs of execution layer (formerly Ethereum 1.0) nodes. Each time Teku makes a call, it finds
+Comma-separated list of JSON-RPC URLs of execution layer (Ethereum 1.0) nodes. Each time Teku makes a call, it finds
 the first provider in the list that is available, on the right chain, and in sync. This option must
 be specified if running a validator.
 
@@ -837,7 +837,7 @@ Possible values are:
 | `prater`  | Consensus layer | Test       | Multi-client testnet.                            |
 
 Predefined networks can provide defaults such as the initial state of the network,
-bootnodes, and the address of the execution layer (formerly Ethereum 1.0) deposit contract.
+bootnodes, and the address of the deposit contract.
 
 ### p2p-advertised-ip
 

--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -288,7 +288,7 @@ is specified using [`--data-base-path`](#data-base-path-data-path).
     eth1-deposit-contract-address: "0x77f7bED277449F51505a4C54550B074030d989bC"
     ```
 
-Ethereum 1.0 address of the deposit contract. Only required when creating a custom network.
+Execution layer (formerly Ethereum 1.0) address of the deposit contract. Only required when creating a custom network.
 
 The deposit contract address can also be defined in:
 
@@ -353,7 +353,7 @@ receiving warnings that the ETH1 node is unavailable.
     eth1-endpoint: ["http://localhost:8545","https://mainnet.infura.io/v3/d0e21ccd0b1e4eef7784422eabc51111"]
     ```
 
-Comma-separated list of JSON-RPC URLs of Ethereum 1.0 nodes. Each time Teku makes a call, it finds
+Comma-separated list of JSON-RPC URLs of execution layer (formerly Ethereum 1.0) nodes. Each time Teku makes a call, it finds
 the first provider in the list that is available, on the right chain, and in sync. This option must
 be specified if running a validator.
 
@@ -824,20 +824,20 @@ The default is `8008`.
 
 Predefined network configuration.
 Accepts a predefined network name, or file path or URL to a YAML configuration file. See the
-[Ethereum 2.0 specification] for examples.
+[consensus specification] for examples.
 
 The default is `mainnet`.
 
 Possible values are:
 
-| Network   | Chain   | Type       | Description                                      |
-|:----------|:--------|:-----------|:-------------------------------------------------|
-| `mainnet` | Eth 2.0 | Production | Main network.                                    |
-| `minimal` | Eth 2.0 | Test       | Used for local testing and development networks. |
-| `prater`  | Eth 2.0 | Test       | Multi-client testnet.                            |
+| Network   | Chain           | Type       | Description                                      |
+|:----------|:----------------|:-----------|:-------------------------------------------------|
+| `mainnet` | Consensus layer | Production | Main network.                                    |
+| `minimal` | Consensus layer | Test       | Used for local testing and development networks. |
+| `prater`  | Consensus layer | Test       | Multi-client testnet.                            |
 
 Predefined networks can provide defaults such as the initial state of the network,
-bootnodes, and the address of the Ethereum 1.0 deposit contract.
+bootnodes, and the address of the execution layer (formerly Ethereum 1.0) deposit contract.
 
 ### p2p-advertised-ip
 
@@ -2027,5 +2027,5 @@ or clear your weak subjectivity settings.
 [weak subjectivity period]: ../../Concepts/Weak-Subjectivity.md
 [load new validators without restarting Teku]: ../../HowTo/Load-Validators-No-Restart.md
 [recent finalized checkpoint state from which to sync]: ../../HowTo/Get-Started/Checkpoint-Start.md
-[Ethereum 2.0 specification]: https://github.com/ethereum/eth2.0-specs/tree/master/configs
+[consensus specification]: https://github.com/ethereum/consensus-specs/tree/master/configs
 [metrics]: ../../HowTo/Monitor/Metrics.md

--- a/docs/Reference/CLI/Subcommands/Admin.md
+++ b/docs/Reference/CLI/Subcommands/Admin.md
@@ -225,7 +225,7 @@ is specified using [`--data-base-path`](#data-base-path-data-path).
     eth1-deposit-contract-address: "0x77f7bED277449F51505a4C54550B074030d989bC"
     ```
 
-Ethereum 1.0 address of the deposit contract. Only required when creating a custom network.
+Execution layer (formerly Ethereum 1.0) address of the deposit contract. Only required when creating a custom network.
 
 #### `network`
 
@@ -258,14 +258,14 @@ to a YAML configuration file. The default is `mainnet`.
 
 Possible values are:
 
-| Network   | Chain   | Type        | Description                                      |
-|-----------|---------|-------------|--------------------------------------------------|
-| `mainnet` | Eth 2.0 | Production  | Main network.                                    |
-| `minimal` | Eth 2.0 | Test        | Used for local testing and development networks. |
-| `prater`  | Eth 2.0 | Test        | Multi-client testnet.                            |
+| Network   | Chain           | Type        | Description                                      |
+|-----------|-----------------|-------------|--------------------------------------------------|
+| `mainnet` | Consensus layer | Production  | Main network.                                    |
+| `minimal` | Consensus layer | Test        | Used for local testing and development networks. |
+| `prater`  | Consensus layer | Test        | Multi-client testnet.                            |
 
 Predefined networks can provide defaults such the initial state of the network,
-bootnodes, and the address of the Ethereum 1.0 deposit contract.
+bootnodes, and the address of the execution layer (formerly Ethereum 1.0) deposit contract.
 
 ### `display-state`
 
@@ -482,7 +482,7 @@ is specified using [`--data-base-path`](#data-base-path-data-path).
     eth1-deposit-contract-address: "0x77f7bED277449F51505a4C54550B074030d989bC"
     ```
 
-Ethereum 1.0 address of the deposit contract. Only required when creating a custom network.
+Execution layer (formerly Ethereum 1.0) address of the deposit contract. Only required when creating a custom network.
 
 #### `network`
 
@@ -515,11 +515,11 @@ to a YAML configuration file. The default is `mainnet`.
 
 Possible values are:
 
-| Network   | Chain   | Type        | Description                                                         |
-|-----------|---------|-------------|---------------------------------------------------------------------|
-| `mainnet` | Eth 2.0 | Production  | Main network.                                                       |
-| `minimal` | Eth 2.0 | Test        | Used for local testing and development networks.                    |
-| `prater` | Eth 2.0 | Test        | Multi-client testnet.                                                |
+| Network   | Chain           | Type        | Description                                                |
+|-----------|-----------------|-------------|------------------------------------------------------------|
+| `mainnet` | Consensus layer | Production  | Main network.                                              |
+| `minimal` | Consensus layer | Test        | Used for local testing and development networks.           |
+| `prater`  | Consensus layer | Test        | Multi-client testnet.                                      |
 
 Predefined networks can provide defaults such the initial state of the network,
-bootnodes, and the address of the Ethereum 1.0 deposit contract.
+bootnodes, and the address of the execution layer (formerly Ethereum 1.0) deposit contract.

--- a/docs/Reference/CLI/Subcommands/Admin.md
+++ b/docs/Reference/CLI/Subcommands/Admin.md
@@ -225,7 +225,7 @@ is specified using [`--data-base-path`](#data-base-path-data-path).
     eth1-deposit-contract-address: "0x77f7bED277449F51505a4C54550B074030d989bC"
     ```
 
-Execution layer (formerly Ethereum 1.0) address of the deposit contract. Only required when creating a custom network.
+The address of the deposit contract. Only required when creating a custom network.
 
 #### `network`
 
@@ -265,7 +265,7 @@ Possible values are:
 | `prater`  | Consensus layer | Test        | Multi-client testnet.                            |
 
 Predefined networks can provide defaults such the initial state of the network,
-bootnodes, and the address of the execution layer (formerly Ethereum 1.0) deposit contract.
+bootnodes, and the address of the deposit contract.
 
 ### `display-state`
 
@@ -482,7 +482,7 @@ is specified using [`--data-base-path`](#data-base-path-data-path).
     eth1-deposit-contract-address: "0x77f7bED277449F51505a4C54550B074030d989bC"
     ```
 
-Execution layer (formerly Ethereum 1.0) address of the deposit contract. Only required when creating a custom network.
+The address of the deposit contract. Only required when creating a custom network.
 
 #### `network`
 
@@ -522,4 +522,4 @@ Possible values are:
 | `prater`  | Consensus layer | Test        | Multi-client testnet.                                      |
 
 Predefined networks can provide defaults such the initial state of the network,
-bootnodes, and the address of the execution layer (formerly Ethereum 1.0) deposit contract.
+bootnodes, and the address of the deposit contract.

--- a/docs/Reference/CLI/Subcommands/Migrate-Database.md
+++ b/docs/Reference/CLI/Subcommands/Migrate-Database.md
@@ -125,14 +125,14 @@ is specified using [`--data-base-path`](#data-base-path-data-path).
 
 Predefined network configuration.
 Accepts a predefined network name, or file path or URL to a YAML configuration file. See the
-[Ethereum 2.0 specification] for examples.
+[consenus specification](https://github.com/ethereum/consensus-specs/tree/master/configs) for examples.
 
 The default is `mainnet`.
 
 Possible values are:
 
-| Network   | Chain   | Type       | Description                                      |
-|:----------|:--------|:-----------|:-------------------------------------------------|
-| `mainnet` | Eth 2.0 | Production | Main network.                                    |
-| `minimal` | Eth 2.0 | Test       | Used for local testing and development networks. |
-| `prater`  | Eth 2.0 | Test       | Multi-client testnet.                            |
+| Network   | Chain           | Type       | Description                                      |
+|:----------|:----------------|:-----------|:-------------------------------------------------|
+| `mainnet` | Consensus layer | Production | Main network.                                    |
+| `minimal` | Consensus layer | Test       | Used for local testing and development networks. |
+| `prater`  | Consensus layer | Test       | Multi-client testnet.                            |

--- a/docs/Reference/CLI/Subcommands/Migrate-Database.md
+++ b/docs/Reference/CLI/Subcommands/Migrate-Database.md
@@ -125,7 +125,7 @@ is specified using [`--data-base-path`](#data-base-path-data-path).
 
 Predefined network configuration.
 Accepts a predefined network name, or file path or URL to a YAML configuration file. See the
-[consenus specification](https://github.com/ethereum/consensus-specs/tree/master/configs) for examples.
+[consensus specification](https://github.com/ethereum/consensus-specs/tree/master/configs) for examples.
 
 The default is `mainnet`.
 

--- a/docs/Reference/CLI/Subcommands/Slashing-Protection.md
+++ b/docs/Reference/CLI/Subcommands/Slashing-Protection.md
@@ -305,14 +305,14 @@ to a YAML configuration file. The default is `mainnet`.
 
 Possible values are:
 
-| Network   | Chain   | Type        | Description                                      |
-|-----------|---------|-------------|--------------------------------------------------|
-| `mainnet` | Eth 2.0 | Production  | Main network.                                    |
-| `minimal` | Eth 2.0 | Test        | Used for local testing and development networks. |
-| `prater`  | Eth 2.0 | Test        | Multi-client testnet.                            |
+| Network   | Chain           | Type        | Description                                      |
+|-----------|-----------------|-------------|--------------------------------------------------|
+| `mainnet` | Consensus layer | Production  | Main network.                                    |
+| `minimal` | Consensus layer | Test        | Used for local testing and development networks. |
+| `prater`  | Consensus layer | Test        | Multi-client testnet.                            |
 
 Predefined networks can provide defaults such the initial state of the network,
-bootnodes, and the address of the Ethereum 1.0 deposit contract.
+bootnodes, and the address of the execution layer (formerly Ethereum 1.0) deposit contract.
 
 ### `slot`
 

--- a/docs/Reference/CLI/Subcommands/Slashing-Protection.md
+++ b/docs/Reference/CLI/Subcommands/Slashing-Protection.md
@@ -312,7 +312,7 @@ Possible values are:
 | `prater`  | Consensus layer | Test        | Multi-client testnet.                            |
 
 Predefined networks can provide defaults such the initial state of the network,
-bootnodes, and the address of the execution layer (formerly Ethereum 1.0) deposit contract.
+bootnodes, and the address of the deposit contract.
 
 ### `slot`
 

--- a/docs/Tutorials/Configure-External-Signer-TLS.md
+++ b/docs/Tutorials/Configure-External-Signer-TLS.md
@@ -22,7 +22,7 @@ keystores and the truststore that contain self-signed certificates.
     validators on the testnet.
 - [Teku Installed](../HowTo/Get-Started/Installation-Options/Install-Binaries.md).
 - [Java `keytool`](https://docs.oracle.com/en/java/javase/12/tools/keytool.html).
-- A running Ethereum 1.0 node such as [Hyperledger Besu], or cloud-based service such as [Infura]
+- A running execution layer node such as [Hyperledger Besu], or cloud-based service such as [Infura]
     synced to the Goerli testnet.
 
 This tutorial connects to an ETH2 testnet, and uses [Infura] to access the

--- a/docs/Tutorials/Configure-External-Signer-TLS.md
+++ b/docs/Tutorials/Configure-External-Signer-TLS.md
@@ -22,7 +22,7 @@ keystores and the truststore that contain self-signed certificates.
     validators on the testnet.
 - [Teku Installed](../HowTo/Get-Started/Installation-Options/Install-Binaries.md).
 - [Java `keytool`](https://docs.oracle.com/en/java/javase/12/tools/keytool.html).
-- A running execution layer node such as [Hyperledger Besu], or cloud-based service such as [Infura]
+- A running execution client such as [Hyperledger Besu], or cloud-based service such as [Infura]
     synced to the Goerli testnet.
 
 This tutorial connects to an ETH2 testnet, and uses [Infura] to access the

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,14 +2,14 @@
 
 ## What is Teku?
 
-Teku is an open-source consensus layer (formerly called [Ethereum 2.0](https://blog.ethereum.org/2022/01/24/the-great-eth2-renaming/)) client written in Java.
-Teku contains a full Beacon node implementation and a validator client for participating in consensus.
+Teku is an open-source Ethereum consensus client (sometimes called an [Ethereum 2.0](https://blog.ethereum.org/2022/01/24/the-great-eth2-renaming/) client) written in Java.
+Teku contains a full beacon node implementation and a validator client for participating in consensus.
 
 ## What can you do with Teku?
 
 Teku:
 
-* Runs the Beacon node synchronization and consensus.
+* Runs the beacon node synchronization and consensus.
 * Proposes and attests blocks.
 * Provides enterprise focused metrics with Prometheus.
 * Has REST APIs for managing consensus layer node operations.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,8 @@
 
 ## What is Teku?
 
-Teku is an open-source Ethereum 2.0 client written in Java. Teku contains a full Beacon node implementation
-and a validator client for participating in consensus.
+Teku is an open-source consensus layer (formerly called [Ethereum 2.0](https://blog.ethereum.org/2022/01/24/the-great-eth2-renaming/)) client written in Java.
+Teku contains a full Beacon node implementation and a validator client for participating in consensus.
 
 ## What can you do with Teku?
 
@@ -12,10 +12,10 @@ Teku:
 * Runs the Beacon node synchronization and consensus.
 * Proposes and attests blocks.
 * Provides enterprise focused metrics with Prometheus.
-* Has REST APIs for managing Eth 2.0 node operations.
+* Has REST APIs for managing consensus layer node operations.
 * Has external key management to manage validator signing keys.
 
-## New to Ethereum 2.0?
+## New to Teku?
 
 Get started by running Teku with Docker or installing Teku.
 You can:


### PR DESCRIPTION
## Pull request checklist

## Describe the change
Update the Eth1 to "execution layer" and Eth2 to "consensus layer" per the [Ethereum Foundation update](https://blog.ethereum.org/2022/01/24/the-great-eth2-renaming/). 
<!-- A clear and concise description of what this PR changes in the documentation. -->

## Issue fixed
Fixes #333 
<!-- Except for minor changes (typos, commas) it's required to have a Github issue linked to your
pull request.

Use the following to make Github close the issue automatically when merging the PR:
fixes #{your issue number}
If multiple issues are involved, use one line for each issue.

If you don't want to close the issue, use:
see #{your issue number} -->

## Impacted parts <!-- check as many boxes as needed -->

### For content changes

- [x] Doc content
- [ ] Doc pages organisation

### For tools changes

- [ ] CircleCI workflow
- [ ] Build and QA tools (lint, vale,…)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] ReadTheDocs configuration
- [ ] GitHub integration

## Testing

<!-- Steps to follow to review and test your changes.
Add links to preview the pages changes here.
Link format is https://pegasys-teku--{your PR number}.org.readthedocs.build/en/{your PR number}/
Where {your PR number} must be replaced by the number of this PR, for instance 123
-->

## Screenshots / recording
https://pegasys-teku--341.com.readthedocs.build/en/341/
<!-- If it helps to understand your change, you may link an annotated screenshot or a small demo video. -->
