### PR TITLE
Document metrics publish CLI options

### DIFF
--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -796,6 +796,63 @@ Host on which Prometheus accesses Teku metrics. The default is `127.0.0.1`.
 Specifies the port (TCP) on which [Prometheus](https://prometheus.io/) accesses Teku metrics.
 The default is `8008`.
 
+### metrics-publish-endpoint
+
+=== "Syntax"
+
+    ```bash
+    --metrics-publish-endpoint=<URL>
+    ```
+
+=== "Example"
+
+    ```bash
+    --metrics-publish-endpoint=https://beaconcha.in/api/v1/client/metrics?apikey={apikey}
+    ```
+
+=== "Environment variable"
+
+    ```bash
+    TEKU_METRICS_PUBLISH_ENDPOINT=https://beaconcha.in/api/v1/client/metrics?apikey={apikey}
+    ```
+
+=== "Configuration file"
+
+    ```bash
+    metrics-publish-endpoint: "https://beaconcha.in/api/v1/client/metrics?apikey={apikey}"
+    ```
+
+Endpoint URL of an external service such as [beaconcha.in](https://beaconcha.in/) to which Teku publishes metrics for node monitoring.
+
+### metrics-publish-interval
+
+=== "Syntax"
+
+    ```bash
+    --metrics-publish-interval=<INTEGER>
+    ```
+
+=== "Example"
+
+    ```bash
+    --metrics-publish-interval=60
+    ```
+
+=== "Environment variable"
+
+    ```bash
+    TEKU_METRICS_PUBLISH_INTERVAL=60
+    ```
+
+=== "Configuration file"
+
+    ```bash
+    metrics-publish-interval: "60"
+    ```
+
+Interval between metric publications to the external service defined in [metrics-publish-endpoint](#metrics-publish-endpoint), measured in seconds.
+The default is `60`.
+
 ### network
 
 === "Syntax"


### PR DESCRIPTION
## Describe the change
Document the `metrics-publish-endpoint` and `metrics-publish-interval` CLI option
<!-- A clear and concise description of what this PR changes in the documentation. -->

## Issue fixed
Fixes #345 
<!-- Except for minor changes (typos, commas) it's required to have a Github issue linked to your
pull request.

Use the following to make Github close the issue automatically when merging the PR:
fixes #{your issue number}
If multiple issues are involved, use one line for each issue.

If you don't want to close the issue, use:
see #{your issue number} -->

## Impacted parts <!-- check as many boxes as needed -->

### For content changes

- [x] Doc content
- [ ] Doc pages organisation

### For tools changes

- [ ] CircleCI workflow
- [ ] Build and QA tools (lint, vale,…)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] ReadTheDocs configuration
- [ ] GitHub integration

## Testing
https://pegasys-teku--347.com.readthedocs.build/en/347/Reference/CLI/CLI-Syntax/#metrics-publish-endpoint
<!-- Steps to follow to review and test your changes.
Add links to preview the pages changes here.
Link format is https://pegasys-teku--{your PR number}.org.readthedocs.build/en/{your PR number}/
Where {your PR number} must be replaced by the number of this PR, for instance 123
-->