### PR TITLE
Convert addresses to checksum encoded versions

### DIFF
--- a/docs/HowTo/Get-Started/Connect/Connect-To-Mainnet.md
+++ b/docs/HowTo/Get-Started/Connect/Connect-To-Mainnet.md
@@ -34,7 +34,7 @@ New validators make deposits on the execution layer, and existing consensus laye
 process the deposits to allow the new validators to join.
 
 Deposits are made into a deposit contract on the execution layer Mainnet. The deposit contract address
-is `0x00000000219ab540356cbb839cbe05303d7705fa`.
+is `0x00000000219ab540356cBB839Cbe05303d7705Fa`.
 
 The steps to run a consensus layer validator on Mainnet are:
 

--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -2440,19 +2440,19 @@ The default is `false`.
 === "Example"
 
     ```bash
-    --validators-proposer-default-fee-recipient=0xfe3b557e8fb62b89f4916b721be55ceb828dbd73
+    --validators-proposer-default-fee-recipient=0xFE3B557E8Fb62b89F4916B721be55cEb828dBd73
     ```
 
 === "Environment variable"
 
     ```bash
-    TEKU_VALIDATORS_PROPOSER_DEFAULT_FEE_RECIPIENT=0xfe3b557e8fb62b89f4916b721be55ceb828dbd73
+    TEKU_VALIDATORS_PROPOSER_DEFAULT_FEE_RECIPIENT=0xFE3B557E8Fb62b89F4916B721be55cEb828dBd73
     ```
 
 === "Configuration file"
 
     ```bash
-    validators-proposer-default-fee-recipient: "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73"
+    validators-proposer-default-fee-recipient: "0xFE3B557E8Fb62b89F4916B721be55cEb828dBd73"
     ```
 
 Default fee recipient for all validator keys.


### PR DESCRIPTION
## PR Description

Add checksums to remaining Eth1 addresses without checksums. When https://github.com/ConsenSys/teku/pull/5418 is merged, these addresses will need to have checksums.

These are the updated addresses (the page will show the checksum encoded version):

* https://etherscan.io/address/0x00000000219ab540356cbb839cbe05303d7705fa
* https://etherscan.io/address/0xfe3b557e8fb62b89f4916b721be55ceb828dbd73

## Impacted parts

<!-- Check the item from the following lists that your PR impacts. You can check multiple boxes. -->

For content changes:

- [x] Documentation content
- [ ] Documentation page organization