### PR TITLE
Doc missing network options

### DIFF
--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -960,6 +960,8 @@ Possible values are:
 | `mainnet` | Consensus layer | Production | Main network.                                    |
 | `minimal` | Consensus layer | Test       | Used for local testing and development networks. |
 | `prater`  | Consensus layer | Test       | Multi-client testnet.                            |
+| `kiln`    | Consensus layer | Test       | Multi-client testnet.                            |
+| `ropsten` | Consensus layer | Test       | Multi-client testnet.                            |
 
 Predefined networks can provide defaults such as the initial state of the network,
 bootnodes, and the address of the deposit contract.

--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -959,8 +959,6 @@ Possible values are:
 |:-------------|:----------------|:-----------|:-------------------------------------------------|
 | `mainnet`    | Consensus layer | Production | Main network.                                    |
 | `minimal`    | Consensus layer | Test       | Used for local testing and development networks. |
-| `swift`      | Consensus layer | Test       | Used for local testing and development networks. |
-| `less-swift` | Consensus layer | Test       | Used for local testing and development networks. |
 | `prater`     | Consensus layer | Test       | Multi-client testnet.                            |
 | `kiln`       | Consensus layer | Test       | Multi-client testnet.                            |
 | `ropsten`    | Consensus layer | Test       | Multi-client testnet.                            |

--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -955,13 +955,16 @@ The default is `mainnet`.
 
 Possible values are:
 
-| Network   | Chain           | Type       | Description                                      |
-|:----------|:----------------|:-----------|:-------------------------------------------------|
-| `mainnet` | Consensus layer | Production | Main network.                                    |
-| `minimal` | Consensus layer | Test       | Used for local testing and development networks. |
-| `prater`  | Consensus layer | Test       | Multi-client testnet.                            |
-| `kiln`    | Consensus layer | Test       | Multi-client testnet.                            |
-| `ropsten` | Consensus layer | Test       | Multi-client testnet.                            |
+| Network      | Chain           | Type       | Description                                      |
+|:-------------|:----------------|:-----------|:-------------------------------------------------|
+| `mainnet`    | Consensus layer | Production | Main network.                                    |
+| `minimal`    | Consensus layer | Test       | Used for local testing and development networks. |
+| `swift`      | Consensus layer | Test       | Used for local testing and development networks. |
+| `less-swift` | Consensus layer | Test       | Used for local testing and development networks. |
+| `prater`     | Consensus layer | Test       | Multi-client testnet.                            |
+| `kiln`       | Consensus layer | Test       | Multi-client testnet.                            |
+| `ropsten`    | Consensus layer | Test       | Multi-client testnet.                            |
+| `gnosis`     | Consensus layer | Test       | Multi-client testnet.                            |
 
 Predefined networks can provide defaults such as the initial state of the network,
 bootnodes, and the address of the deposit contract.


### PR DESCRIPTION
# Pull request checklist

Use the following template to make sure your PR fits the Teku documentation standard.

## Before creating the PR

Make sure that:

- [x] You've read the [contribution guidelines](https://consensys.net/docs/doctools/).
- [x] You've [previewed your changes locally](https://consensys.net/docs/doctools/en/latest/preview/old-system/#preview-locally).

## Describe the change

<!-- Add a clear and concise description of what your PR changes in the documentation. -->

Add ropsten, kiln, gnosis, swift, and less-swift as supported values for the `network` option.

## Issue fixed

<!-- Link to the GitHub issue that your PR addresses.

Add "fixes #{your issue number}" to close the issue automatically when the PR is merged.

If your PR doesn't completely fix the issue, add "see #{your issue number}" to link to the issue
without automatically closing it. -->

fixes #365 

## Impacted parts

<!-- Check the item from the following lists that your PR impacts. You can check multiple boxes. -->

For content changes:

- [x] Documentation content
- [ ] Documentation page organization

For tool changes:

- [ ] CircleCI workflow
- [ ] Build and QA tools (for example lint or vale)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] Read the Docs configuration
- [ ] GitHub integration

## After creating your PR and tests have finished

Make sure that:

- [ ] You've [fixed any issues](https://consensys.net/docs/doctools/en/latest/contribute/fix-cicd-errors/) raised by the tests.
- [ ] You've [previewed your changes on Read the Docs](https://consensys.net/docs/doctools/en/latest/preview/old-system/#preview-on-read-the-docs)
  and added a [preview link](#preview).

## Preview

<!-- Add the link to preview your changes on Read the Docs.

The link format is "https://pegasys-teku--{your PR number}.org.readthedocs.build/en/{your PR number}/",
where {your PR number} is replaced by the number of this PR.
-->
