### PR TITLE
Add Sepolia testnet

### DIFF
--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -955,14 +955,15 @@ The default is `mainnet`.
 
 Possible values are:
 
-| Network      | Chain           | Type       | Description                                      |
-|:-------------|:----------------|:-----------|:-------------------------------------------------|
-| `mainnet`    | Consensus layer | Production | Main network.                                    |
-| `minimal`    | Consensus layer | Test       | Used for local testing and development networks. |
-| `prater`     | Consensus layer | Test       | Multi-client testnet.                            |
-| `kiln`       | Consensus layer | Test       | Multi-client testnet.                            |
-| `ropsten`    | Consensus layer | Test       | Multi-client testnet.                            |
-| `gnosis`     | Consensus layer | Test       | Multi-client testnet.                            |
+| Network      | Chain           | Type       | Description                                     |
+|:-------------|:----------------|:-----------|:------------------------------------------------|
+| `mainnet`    | Consensus layer | Production | Main network                                    |
+| `minimal`    | Consensus layer | Test       | Used for local testing and development networks |
+| `prater`     | Consensus layer | Test       | Multi-client testnet                            |
+| `kiln`       | Consensus layer | Test       | Multi-client testnet                            |
+| `ropsten`    | Consensus layer | Test       | Multi-client testnet                            |
+| `gnosis`     | Consensus layer | Test       | Multi-client testnet                            |
+| `sepolia`    | Consensus layer | Test       | Multi-client testnet                            |
 
 Predefined networks can provide defaults such as the initial state of the network,
 bootnodes, and the address of the deposit contract.

--- a/docs/Reference/CLI/Subcommands/Admin.md
+++ b/docs/Reference/CLI/Subcommands/Admin.md
@@ -520,6 +520,10 @@ Possible values are:
 | `mainnet` | Consensus layer | Production  | Main network.                                              |
 | `minimal` | Consensus layer | Test        | Used for local testing and development networks.           |
 | `prater`  | Consensus layer | Test        | Multi-client testnet.                                      |
+| `kiln`    | Consensus layer | Test        | Multi-client testnet                                       |
+| `ropsten` | Consensus layer | Test        | Multi-client testnet                                       |
+| `gnosis`  | Consensus layer | Test        | Multi-client testnet                                       |
+| `sepolia` | Consensus layer | Test        | Multi-client testnet                                       |
 
 Predefined networks can provide defaults such the initial state of the network,
 bootnodes, and the address of the deposit contract.

--- a/docs/Reference/CLI/Subcommands/Admin.md
+++ b/docs/Reference/CLI/Subcommands/Admin.md
@@ -515,15 +515,15 @@ to a YAML configuration file. The default is `mainnet`.
 
 Possible values are:
 
-| Network   | Chain           | Type        | Description                                                |
-|-----------|-----------------|-------------|------------------------------------------------------------|
-| `mainnet` | Consensus layer | Production  | Main network.                                              |
-| `minimal` | Consensus layer | Test        | Used for local testing and development networks.           |
-| `prater`  | Consensus layer | Test        | Multi-client testnet.                                      |
-| `kiln`    | Consensus layer | Test        | Multi-client testnet                                       |
-| `ropsten` | Consensus layer | Test        | Multi-client testnet                                       |
-| `gnosis`  | Consensus layer | Test        | Multi-client testnet                                       |
-| `sepolia` | Consensus layer | Test        | Multi-client testnet                                       |
+| Network   | Chain           | Type        | Description                                               |
+|-----------|-----------------|-------------|-----------------------------------------------------------|
+| `mainnet` | Consensus layer | Production  | Main network                                              |
+| `minimal` | Consensus layer | Test        | Used for local testing and development networks           |
+| `prater`  | Consensus layer | Test        | Multi-client testnet                                      |
+| `kiln`    | Consensus layer | Test        | Multi-client testnet                                      |
+| `ropsten` | Consensus layer | Test        | Multi-client testnet                                      |
+| `gnosis`  | Consensus layer | Test        | Multi-client testnet                                      |
+| `sepolia` | Consensus layer | Test        | Multi-client testnet                                      |
 
 Predefined networks can provide defaults such the initial state of the network,
 bootnodes, and the address of the deposit contract.

--- a/docs/Reference/CLI/Subcommands/Migrate-Database.md
+++ b/docs/Reference/CLI/Subcommands/Migrate-Database.md
@@ -133,8 +133,8 @@ Possible values are:
 
 | Network   | Chain           | Type       | Description                                      |
 |:----------|:----------------|:-----------|:-------------------------------------------------|
-| `mainnet` | Consensus layer | Production | Main network.                                    |
-| `minimal` | Consensus layer | Test       | Used for local testing and development networks. |
+| `mainnet` | Consensus layer | Production | Main network                                     |
+| `minimal` | Consensus layer | Test       | Used for local testing and development networks  |
 | `prater`  | Consensus layer | Test       | Multi-client testnet.                            |
 | `kiln`    | Consensus layer | Test       | Multi-client testnet                             |
 | `ropsten` | Consensus layer | Test       | Multi-client testnet                             |

--- a/docs/Reference/CLI/Subcommands/Migrate-Database.md
+++ b/docs/Reference/CLI/Subcommands/Migrate-Database.md
@@ -135,7 +135,7 @@ Possible values are:
 |:----------|:----------------|:-----------|:-------------------------------------------------|
 | `mainnet` | Consensus layer | Production | Main network                                     |
 | `minimal` | Consensus layer | Test       | Used for local testing and development networks  |
-| `prater`  | Consensus layer | Test       | Multi-client testnet.                            |
+| `prater`  | Consensus layer | Test       | Multi-client testnet                             |
 | `kiln`    | Consensus layer | Test       | Multi-client testnet                             |
 | `ropsten` | Consensus layer | Test       | Multi-client testnet                             |
 | `gnosis`  | Consensus layer | Test       | Multi-client testnet                             |

--- a/docs/Reference/CLI/Subcommands/Migrate-Database.md
+++ b/docs/Reference/CLI/Subcommands/Migrate-Database.md
@@ -136,3 +136,7 @@ Possible values are:
 | `mainnet` | Consensus layer | Production | Main network.                                    |
 | `minimal` | Consensus layer | Test       | Used for local testing and development networks. |
 | `prater`  | Consensus layer | Test       | Multi-client testnet.                            |
+| `kiln`    | Consensus layer | Test       | Multi-client testnet                             |
+| `ropsten` | Consensus layer | Test       | Multi-client testnet                             |
+| `gnosis`  | Consensus layer | Test       | Multi-client testnet                             |
+| `sepolia` | Consensus layer | Test       | Multi-client testnet                             |


### PR DESCRIPTION
# Pull request checklist

Use the following template to make sure your PR fits the Teku documentation standard.

## Before creating the PR

Make sure that:

- [x] You've read the [contribution guidelines](https://consensys.net/docs/doctools/).
- [x] You've [previewed your changes locally](https://consensys.net/docs/doctools/en/latest/preview/old-system/#preview-locally).

## Describe the change
Add Sepolia testnet and other missing options to `--network` description
<!-- Add a clear and concise description of what your PR changes in the documentation. -->

## Issue fixed
Fixes #367 
<!-- Link to the GitHub issue that your PR addresses.

Add "fixes #{your issue number}" to close the issue automatically when the PR is merged.

If your PR doesn't completely fix the issue, add "see #{your issue number}" to link to the issue
without automatically closing it. -->

## Impacted parts

<!-- Check the item from the following lists that your PR impacts. You can check multiple boxes. -->

For content changes:

- [x] Documentation content
- [ ] Documentation page organization

For tool changes:

- [ ] CircleCI workflow
- [ ] Build and QA tools (for example lint or vale)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] Read the Docs configuration
- [ ] GitHub integration

## After creating your PR and tests have finished

Make sure that:

- [x] You've [fixed any issues](https://consensys.net/docs/doctools/en/latest/contribute/fix-cicd-errors/) raised by the tests.
- [x] You've [previewed your changes on Read the Docs](https://consensys.net/docs/doctools/en/latest/preview/old-system/#preview-on-read-the-docs)
  and added a [preview link](#preview).

## Preview

<!-- Add the link to preview your changes on Read the Docs.

The link format is "https://pegasys-teku--{your PR number}.org.readthedocs.build/en/{your PR number}/",
where {your PR number} is replaced by the number of this PR.
-->
