### PR TITLE
Supply multiple beacon node endpoints.

### DIFF
--- a/docs/HowTo/Get-Started/Connect/Connect-To-Mainnet.md
+++ b/docs/HowTo/Get-Started/Connect/Connect-To-Mainnet.md
@@ -166,7 +166,7 @@ specify the directory to load multiple keys and passwords from.
 If running the validator client on a separate machine to the beacon node, then run Teku using the
 [`vc`](../../../Reference/CLI/Subcommands/Validator-Client.md) or
 [`validator-client`](../../../Reference/CLI/Subcommands/Validator-Client.md) subcommand, and specify
-the location of the beacon node's API endpoint using
+the location of one or more beacon node API endpoints using
 [`--beacon-node-api-endpoint`](../../../Reference/CLI/Subcommands/Validator-Client.md#beacon-node-api-endpoint).
 
 You also need to specify the validator key files [created earlier](#generate-the-validators-and-send-the-deposits),

--- a/docs/HowTo/Get-Started/Run-Teku.md
+++ b/docs/HowTo/Get-Started/Run-Teku.md
@@ -85,7 +85,7 @@ a Teku as a validator.
 !!! example
 
     ```
-    teku validator-client --network=goerli --beacon-node-api-endpoint=http://192.10.10.101:5051 \
+    teku validator-client --network=goerli --beacon-node-api-endpoint=http://192.10.10.101:5051,http://192.140.110.44:5051 \
     --validator-keys=validator/keys:validator/passwords
     ```
 
@@ -94,9 +94,14 @@ a Teku as a validator.
     keys as command line options to both the beacon node and validator client. This can a
     cause a [slashable offense].
 
-Specify the beacon node using the
-[`--beacon-node-api-endpoint`](../../Reference/CLI/Subcommands/Validator-Client.md#beacon-node-api-endpoint)
+Specify one or more beacon nodes using the
+[`--beacon-node-api-endpoint`](../../Reference/CLI/Subcommands/Validator-Client.md#beacon-node-api-endpoint-beacon-node-api-endpoints)
 option.
+
+!!! important
+
+    You can supply multiple beacon node endpoints to the validator, the first one will be used as the
+    primary node, and others as failovers.
 
 ## Confirm Teku is running
 

--- a/docs/HowTo/Get-Started/Run-Teku.md
+++ b/docs/HowTo/Get-Started/Run-Teku.md
@@ -100,7 +100,7 @@ option.
 
 !!! important
 
-    You can supply multiple beacon node endpoints to the validator, the first one will be used as the
+    You can supply multiple beacon node endpoints to the validator. The first one is used as the
     primary node, and others as failovers.
 
 ## Confirm Teku is running

--- a/docs/Reference/CLI/Subcommands/Validator-Client.md
+++ b/docs/Reference/CLI/Subcommands/Validator-Client.md
@@ -23,7 +23,7 @@ Run a validator client that connects to a remote beacon node.
 === "Environment variable"
 
     ```bash
-    TEKU_BEACON_NODE_ENDPOINT=http://192.138.10.12,http://192.140.11.44:5051
+    TEKU_BEACON_NODE_API_ENDPOINT=http://192.138.10.12,http://192.140.11.44:5051
     ```
 
 === "Configuration file"

--- a/docs/Reference/CLI/Subcommands/Validator-Client.md
+++ b/docs/Reference/CLI/Subcommands/Validator-Client.md
@@ -6,33 +6,39 @@ title: Validator client subcommand options
 
 Run a validator client that connects to a remote beacon node.
 
-## `beacon-node-api-endpoint`
+## `beacon-node-api-endpoint`, `beacon-node-api-endpoints`
 
 === "Syntax"
 
     ```bash
-    teku vc --beacon-node-api-endpoint=<ENDPOINT>
+    teku vc --beacon-node-api-endpoint=<ENDPOINT>[,<ENDPOINT>...]...
     ```
 
 === "Example"
 
     ```bash
-    teku vc --beacon-node-api-endpoint=http://192.138.10.12
+    teku vc --beacon-node-api-endpoint=http://192.138.10.12:5051,http://192.140.11.44:5051
     ```
 
 === "Environment variable"
 
     ```bash
-    TEKU_BEACON_NODE_ENDPOINT=http://192.138.10.12
+    TEKU_BEACON_NODE_ENDPOINT=http://192.138.10.12,http://192.140.11.44:5051
     ```
 
 === "Configuration file"
 
     ```bash
-    beacon-node-api-endpoint: "http://192.138.10.12"
+    beacon-node-api-endpoint: ["http://192.138.10.12","http://192.140.11.44:5051"]
     ```
 
-Endpoint of the beacon node's REST API. The default is `http://127.0.0.1:5051`.
+Endpoint of the beacon node's REST API. You can configure multiple beacon nodes by providing a
+comma-separated list of beacon node API endpoints.
+
+If multiple beacon node endpoints are configured, the first one will be used as primary and others
+as failovers.
+
+The default is `http://127.0.0.1:5051`.
 
 ## `config-file`
 

--- a/docs/Reference/CLI/Subcommands/Validator-Client.md
+++ b/docs/Reference/CLI/Subcommands/Validator-Client.md
@@ -35,7 +35,7 @@ Run a validator client that connects to a remote beacon node.
 Endpoint of the beacon node's REST API. You can configure multiple beacon nodes by providing a
 comma-separated list of beacon node API endpoints.
 
-If multiple beacon node endpoints are configured, the first one will be used as primary and others
+If multiple beacon node endpoints are configured, the first one is used as primary and others
 as failovers.
 
 The default is `http://127.0.0.1:5051`.


### PR DESCRIPTION
Signed-off-by: bgravenorst <byron.gravenorst@consensys.net>

## Before creating the PR

## Describe the change

We can now configure multiple beacon nodes for a validator client.

## Issue fixed

Fixes #384 

## Preview

- https://pegasys-teku--386.com.readthedocs.build/en/386/Reference/CLI/Subcommands/Validator-Client/#beacon-node-api-endpoint-beacon-node-api-endpoints
- https://pegasys-teku--386.com.readthedocs.build/en/386/HowTo/Get-Started/Run-Teku/#start-the-validator
