### PR TITLE
Fix docker-compose.yml with Engine's properties

### DIFF
--- a/docs/HowTo/Get-Started/Installation-Options/Run-Docker-Image.md
+++ b/docs/HowTo/Get-Started/Installation-Options/Run-Docker-Image.md
@@ -100,17 +100,21 @@ to start the container.
       besu_node:
         image: hyperledger/besu:latest
         command: ["--network=goerli",
-                  "--data-path=/opt/besu/data/data",
+                  "--data-path=/opt/besu/data",
                   "--host-allowlist=*",
                   "--sync-mode=FAST",
                   "--rpc-http-enabled",
                   "--rpc-http-cors-origins=*",
                   "--rpc-http-api=ETH,NET,CLIQUE,DEBUG,MINER,NET,PERM,ADMIN,EEA,TXPOOL,PRIV,WEB3"]
+                  "--engine-jwt-secret=/opt/besu/data/token.txt",
+                  "--engine-host-allowlist=*",
+                  "--engine-rpc-enabled=true"
         volumes:
           - ./besu:/opt/besu/data
         ports:
-          # Map the p2p port(30303) and RPC HTTP port(8545)
+          # Map the p2p port(30303), RPC HTTP port(8545) and engine port (8551)
           - "8545:8545"
+          - "8551:8551"
           - "30303:30303/tcp"
           - "30303:30303/udp"
 
@@ -119,8 +123,10 @@ to start the container.
           - "JAVA_OPTS=-Xmx4g"
         image: consensys/teku:latest
         command: ["--network=goerli",
-                  "--data-base-path=/opt/teku/data"
-                  "--eth1-endpoint=http://besu_node:8545",
+                  "--data-base-path=/opt/teku/data",
+                  "--validators-proposer-default-fee-recipient=YOUR_WALLET",
+                  "--ee-endpoint=http://besu_node:8551",
+                  "--ee-jwt-secret-file=/opt/teku/data/token.txt",
                   "--validator-keys=/opt/teku/data/validator/keys:/opt/teku/data/validator/passwords",
                   "--p2p-port=9000",
                   "--rest-api-enabled=true",
@@ -145,16 +151,20 @@ to start the container.
 
       besu_node:
         image: hyperledger/besu:latest
-        command: ["--data-path=/opt/besu/data/data",
+        command: ["--data-path=/opt/besu/data",
                   "--host-allowlist=*",
                   "--rpc-http-enabled",
                   "--rpc-http-cors-origins=*",
-                  "--rpc-http-api=ETH,NET,CLIQUE,DEBUG,MINER,NET,PERM,ADMIN,EEA,TXPOOL,PRIV,WEB3"]
+                  "--rpc-http-api=ETH,NET,CLIQUE,DEBUG,MINER,NET,PERM,ADMIN,EEA,TXPOOL,PRIV,WEB3",
+                  "--engine-jwt-secret=/opt/besu/data/token.txt",
+                  "--engine-host-allowlist=*",
+                  "--engine-rpc-enabled=true"]
         volumes:
           - ./besu:/opt/besu/data
         ports:
-          # Map the p2p port(30303) and RPC HTTP port(8545)
+          # Map the p2p port(30303), RPC HTTP port(8545) and engine port (8551)
           - "8545:8545"
+          - "8551:8551"
           - "30303:30303/tcp"
           - "30303:30303/udp"
 
@@ -162,8 +172,10 @@ to start the container.
         environment:
           - "JAVA_OPTS=-Xmx4g"
         image: consensys/teku:latest
-        command: ["--data-base-path=/opt/teku/data"
-                  "--eth1-endpoint=http://besu_node:8545",
+        command: ["--data-base-path=/opt/teku/data",
+                  "--validators-proposer-default-fee-recipient=YOUR_WALLET",
+                  "--ee-endpoint=http://besu_node:8551",
+                  "--ee-jwt-secret-file=/opt/teku/data/token.txt",
                   "--validator-keys=/opt/teku/data/validator/keys:/opt/teku/data/validator/passwords",
                   "--p2p-port=9000",
                   "--rest-api-enabled=true",


### PR DESCRIPTION
# Pull request checklist

Use the following template to make sure your PR fits the Teku documentation standard.

## Before creating the PR

Make sure that:

- [X] You've read the [contribution guidelines](https://consensys.net/docs/doctools/).
- [X] You've [previewed your changes locally](https://consensys.net/docs/doctools/en/latest/preview/old-system/#preview-locally).

## Describe the change

This corrects a tiny issue (missing comma) of the docker-compose.yml file and updates it to have the new Engine API, JWT and validators fees address parameters.

## Issue fixed

<!-- Link to the GitHub issue that your PR addresses.
fixes #391


## Impacted parts

<!-- Check the item from the following lists that your PR impacts. You can check multiple boxes. -->

For content changes:

- [X] Documentation content
- [ ] Documentation page organization

For tool changes:

- [ ] CircleCI workflow
- [ ] Build and QA tools (for example lint or vale)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] Read the Docs configuration
- [ ] GitHub integration

## After creating your PR and tests have finished

Make sure that:

- [ ] You've [fixed any issues](https://consensys.net/docs/doctools/en/latest/contribute/fix-cicd-errors/) raised by the tests.
- [ ] You've [previewed your changes on Read the Docs](https://consensys.net/docs/doctools/en/latest/preview/old-system/#preview-on-read-the-docs)
  and added a [preview link](#preview).

## Preview

<!-- Add the link to preview your changes on Read the Docs.

The link format is "https://pegasys-teku--{your PR number}.org.readthedocs.build/en/{your PR number}/",
where {your PR number} is replaced by the number of this PR.
-->
