### PR TITLE
Fix code example for proposer configuration

### DIFF
--- a/docs/HowTo/Builder-Network.md
+++ b/docs/HowTo/Builder-Network.md
@@ -67,9 +67,9 @@ Note the `default_config` applies to all validators who don't have their own pro
         }
       },
       "default_config": {
-        "fee_recipient": "0x6e35733c5af9B61374A128e6F85f553aF09ff89A"
+        "fee_recipient": "0x6e35733c5af9B61374A128e6F85f553aF09ff89A",
         "builder": {
-          "enabled": false,
+          "enabled": false
         }
       }
     }


### PR DESCRIPTION
# Pull request checklist

Use the following template to make sure your PR fits the Teku documentation standard.

## Before creating the PR

Make sure that:

- [x] You've read the [contribution guidelines](https://consensys.net/docs/doctools/).
- [x] You've [previewed your changes locally](https://consensys.net/docs/doctools/en/latest/preview/old-system/#preview-locally).

## Describe the change
Fix code example for proposer configuration
<!-- Add a clear and concise description of what your PR changes in the documentation. -->

## Issue fixed
Fixes #393 
<!-- Link to the GitHub issue that your PR addresses.

Add "fixes #{your issue number}" to close the issue automatically when the PR is merged.

If your PR doesn't completely fix the issue, add "see #{your issue number}" to link to the issue
without automatically closing it. -->

## Impacted parts

<!-- Check the item from the following lists that your PR impacts. You can check multiple boxes. -->

For content changes:

- [x] Documentation content
- [ ] Documentation page organization

For tool changes:

- [ ] CircleCI workflow
- [ ] Build and QA tools (for example lint or vale)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] Read the Docs configuration
- [ ] GitHub integration

## After creating your PR and tests have finished

Make sure that:

- [x] You've [fixed any issues](https://consensys.net/docs/doctools/en/latest/contribute/fix-cicd-errors/) raised by the tests.
- [x] You've [previewed your changes on Read the Docs](https://consensys.net/docs/doctools/en/latest/preview/old-system/#preview-on-read-the-docs)
  and added a [preview link](#preview).

## Preview

<!-- Add the link to preview your changes on Read the Docs.

The link format is "https://pegasys-teku--{your PR number}.org.readthedocs.build/en/{your PR number}/",
where {your PR number} is replaced by the number of this PR.
-->
