### PR TITLE
Add multi-domain cert instructions

### DIFF
--- a/docs/Concepts/ArchitectureOverview.md
+++ b/docs/Concepts/ArchitectureOverview.md
@@ -15,5 +15,5 @@ The validator client performs [validator duties](Proof-of-Stake.md).
 You can [run the beacon node only](../HowTo/Get-Started/Run-Teku.md#start-the-beacon-node), or
 [run the beacon node and validator client](../HowTo/Get-Started/Run-Teku.md#start-the-clients-in-a-single-process).
 
-Read more about the [Ethereum consensus client architecture](https://docs.ethhub.io/ethereum-roadmap/ethereum-2.0/eth-2.0-client-architecture/).
+Read more about the [Ethereum consensus client architecture](https://ethereum.org/en/developers/docs/nodes-and-clients/).
 For more information about the Teku architecture, contact us on [Teku Discord channel](https://discord.gg/9mCVSY6).

--- a/docs/HowTo/External-Signer/Manage-keys.md
+++ b/docs/HowTo/External-Signer/Manage-keys.md
@@ -30,7 +30,7 @@ When enabling the validator client API, you must create a keystore.
     === "Example"
 
         ```bash
-        keytool -keystore validator_keystore.p12 -storetype PKCS12 -storepass changeit
+        keytool -kenkeypair -keystore validator_keystore.p12 -storetype PKCS12 -storepass changeit
         ```
 
 2. Create a plain text file (for example `validator_keystore_pass.txt`) that stores the

--- a/docs/HowTo/External-Signer/Manage-keys.md
+++ b/docs/HowTo/External-Signer/Manage-keys.md
@@ -18,7 +18,7 @@ You must also [create a keystore](#create-a-keystore) to enable access.
 When enabling the validator client API, you must create a keystore.
 
 1. Use a tool such as [keytool](https://docs.oracle.com/javase/6/docs/technotes/tools/solaris/keytool.html) or [openSSL](https://www.openssl.org/)
-   to generate a keystore. Note that the `CN` value must be set to the domain name or IP used to access the validator API. 
+   to generate a keystore. Note that the `CN` value must be set to the domain name or IP used to access the validator API.
    Keytool sets this based on the answer to `What is your first and last name?`.
 
     === "Syntax"

--- a/docs/HowTo/External-Signer/Manage-keys.md
+++ b/docs/HowTo/External-Signer/Manage-keys.md
@@ -52,28 +52,28 @@ When the key manager API is accessible via different domain names or IP addresse
 SSL certificate to be accepted as valid. Multiple addresses can be specified when using openSSL to generate the certificate.
 
 1. Create a file openssl.cnf to contain the configuration required for the certificate. For example:
-   
+
    === "Example"
-      
+
       ```properties
       [req]
       distinguished_name = req_distinguished_name
       x509_extensions = v3_req
       prompt = no
-      
+
       [req_distinguished_name]
       countryName = US
       stateOrProvinceName = CA
       localityName = San Francisco
       organizationName = My Organization Name
       organizationalUnitName = My Department Name
-      
+
       [v3_req]
       subjectKeyIdentifier = hash
       authorityKeyIdentifier = keyid,issuer
       basicConstraints = CA:TRUE
       subjectAltName = @alt_names
-      
+
       [alt_names]
       DNS.1 = mydomain.com
       DNS.2 = localhost
@@ -93,14 +93,12 @@ SSL certificate to be accepted as valid. Multiple addresses can be specified whe
       ```bash
       openssl req -x509 -nodes -days <expiry> -newkey rsa:2048 -config openssl.cnf | openssl pkcs12 -export -out <keystore> -passout file:<password-file>
       ```
-   
+
    === "Example"
 
       ```bash
       openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -config openssl.cnf | openssl pkcs12 -export -out validator_keystore.p12 -passout file:validator_keystore_pass.txt
       ```
-
-
 
 ### Authentication
 

--- a/docs/HowTo/External-Signer/Manage-keys.md
+++ b/docs/HowTo/External-Signer/Manage-keys.md
@@ -30,7 +30,7 @@ When enabling the validator client API, you must create a keystore.
     === "Example"
 
         ```bash
-        keytool -kenkeypair -keystore validator_keystore.p12 -storetype PKCS12 -storepass changeit
+        keytool -genkeypair -keystore validator_keystore.p12 -storetype PKCS12 -storepass changeit
         ```
 
 2. Create a plain text file (for example `validator_keystore_pass.txt`) that stores the

--- a/docs/HowTo/External-Signer/Manage-keys.md
+++ b/docs/HowTo/External-Signer/Manage-keys.md
@@ -18,12 +18,13 @@ You must also [create a keystore](#create-a-keystore) to enable access.
 When enabling the validator client API, you must create a keystore.
 
 1. Use a tool such as [keytool](https://docs.oracle.com/javase/6/docs/technotes/tools/solaris/keytool.html) or [openSSL](https://www.openssl.org/)
-   to generate a keystore.
+   to generate a keystore. Note that the `CN` value must be set to the domain name or IP used to access the validator API. 
+   Keytool sets this based on the answer to `What is your first and last name?`.
 
     === "Syntax"
 
         ```bash
-        keytool -keystore <keystore> -storetype PKCS12 -storepass <password>
+        keytool -genkeypair -keystore <keystore> -storetype PKCS12 -storepass <password>
         ```
 
     === "Example"
@@ -44,6 +45,61 @@ When enabling the validator client API, you must create a keystore.
         ```bash
         teku --validator-api-enabled --validator-api-keystore-file=validator_keystore.p12 --validator-api-keystore-password-file=validator_keystore_pass.txt
         ```
+
+#### Supporting Multiple Domains and IPs
+
+When the key manager API is accessible via different domain names or IP addresses, each domain or IP needs to be listed in the
+SSL certificate to be accepted as valid. Multiple addresses can be specified when using openSSL to generate the certificate.
+
+1. Create a file openssl.cnf to contain the configuration required for the certificate. For example:
+   
+   === "Example"
+      
+      ```properties
+      [req]
+      distinguished_name = req_distinguished_name
+      x509_extensions = v3_req
+      prompt = no
+      
+      [req_distinguished_name]
+      countryName = US
+      stateOrProvinceName = CA
+      localityName = San Francisco
+      organizationName = My Organization Name
+      organizationalUnitName = My Department Name
+      
+      [v3_req]
+      subjectKeyIdentifier = hash
+      authorityKeyIdentifier = keyid,issuer
+      basicConstraints = CA:TRUE
+      subjectAltName = @alt_names
+      
+      [alt_names]
+      DNS.1 = mydomain.com
+      DNS.2 = localhost
+      IP.1 = 127.0.0.1
+      IP.2 = 10.0.0.6
+      ```
+      You should adjust the `req_distinguised_name` and `alt_names` sections to match your needs.
+
+2. Create a plain text file (for example `validator_keystore_pass.txt`) that stores the
+   password you defined in the keystore.
+
+3. Generate an x509 certificate from the configuration and convert to PKCS12 format:
+
+   === "Syntax"
+
+      ```bash
+      openssl req -x509 -nodes -days <expiry> -newkey rsa:2048 -config openssl.cnf | openssl pkcs12 -export -out <keystore> -passout file:<password-file>
+      ```
+   
+   === "Example"
+
+      ```bash
+      openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -config openssl.cnf | openssl pkcs12 -export -out validator_keystore.p12 -passout file:validator_keystore_pass.txt
+      ```
+
+
 
 ### Authentication
 

--- a/docs/HowTo/External-Signer/Manage-keys.md
+++ b/docs/HowTo/External-Signer/Manage-keys.md
@@ -80,6 +80,7 @@ SSL certificate to be accepted as valid. Multiple addresses can be specified whe
       IP.1 = 127.0.0.1
       IP.2 = 10.0.0.6
       ```
+
       You should adjust the `req_distinguised_name` and `alt_names` sections to match your needs.
 
 2. Create a plain text file (for example `validator_keystore_pass.txt`) that stores the


### PR DESCRIPTION
## Describe the change

Fixes the key tool command which was missing the `-genkeypair` prefix.

Adds a (very rough) section on using openssl to generate a certificate that supports multiple domain names/ips.

## Issue fixed

Part of https://github.com/ConsenSys/teku/issues/6564

## Impacted parts

<!-- Check the item from the following lists that your PR impacts. You can check multiple boxes. -->

For content changes:

- [x] Documentation content
- [ ] Documentation page organization

For tool changes:

- [ ] CircleCI workflow
- [ ] Build and QA tools (for example lint or vale)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] Read the Docs configuration
- [ ] GitHub integration

## After creating your PR and tests have finished

Make sure that:

- [ ] You've [fixed any issues](https://consensys.net/docs/doctools/en/latest/contribute/fix-cicd-errors/) raised by the tests.
- [ ] You've [previewed your changes on Read the Docs](https://consensys.net/docs/doctools/en/latest/preview/old-system/#preview-on-read-the-docs)
  and added a [preview link](#preview).

## Preview

<!-- Add the link to preview your changes on Read the Docs.

The link format is "https://pegasys-teku--{your PR number}.org.readthedocs.build/en/{your PR number}/",
where {your PR number} is replaced by the number of this PR.
-->
