### PR TITLE
Add beacon-node-ssz-blocks-enabled option

### DIFF
--- a/docs/Reference/CLI/Subcommands/Validator-Client.md
+++ b/docs/Reference/CLI/Subcommands/Validator-Client.md
@@ -44,6 +44,35 @@ as failovers.
 
 The default is `http://127.0.0.1:5051`.
 
+## `beacon-node-ssz-blocks-enabled`
+
+=== "Syntax"
+
+    ```bash
+    teku vc --beacon-node-ssz-blocks-enabled=<BOOLEAN>
+    ```
+
+=== "Example"
+
+    ```bash
+    teku vc --beacon-node-ssz-blocks-enabled=false
+    ```
+
+=== "Environment variable"
+
+    ```bash
+    TEKU_BEACON_NODE_SSZ_BLOCKS_ENABLED=false
+    ```
+
+=== "Configuration file"
+
+    ```bash
+    beacon-node-ssz-blocks-enabled: false
+    ```
+
+Enable or disable the use of SSZ encoding for API requests to the beacon node to create blocks. 
+The default is `true`.
+
 ## `config-file`
 
 === "Syntax"


### PR DESCRIPTION
## Describe the change

Adds the `beacon-node-ssz-blocks-enabled` option to the CLI reference. This is now a supported option and enabled by default.

## Issue fixed

fixes https://github.com/ConsenSys/teku/issues/5588

## Impacted parts

<!-- Check the item from the following lists that your PR impacts. You can check multiple boxes. -->

For content changes:

- [x] Documentation content
- [ ] Documentation page organization

For tool changes:

- [ ] CircleCI workflow
- [ ] Build and QA tools (for example lint or vale)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] Read the Docs configuration
- [ ] GitHub integration

## After creating your PR and tests have finished

Make sure that:

- [ ] You've [fixed any issues](https://consensys.net/docs/doctools/en/latest/contribute/fix-cicd-errors/) raised by the tests.
- [ ] You've [previewed your changes on Read the Docs](https://consensys.net/docs/doctools/en/latest/preview/old-system/#preview-on-read-the-docs)
  and added a [preview link](#preview).

## Preview

<!-- Add the link to preview your changes on Read the Docs.

The link format is "https://pegasys-teku--{your PR number}.org.readthedocs.build/en/{your PR number}/",
where {your PR number} is replaced by the number of this PR.
-->
