### PR TITLE
Add --data-storage-mode=minimal option

### DIFF
--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -231,9 +231,9 @@ This option is ignored if [`--data-storage-mode`](#data-storage-mode) is not set
 
 Set the strategy for handling historical chain data. Valid options are:
 
- * `minimal` - Stores the minimal required data to follow the chain and run validators. Finalized states and historic blocks are pruned.
- * `prune` - Stores all blocks, but finalized states are pruned.
- * `archive` - Stores all blocks and states.
+* `minimal` - Stores the minimal required data to follow the chain and run validators. Finalized states and historic blocks are pruned.
+* `prune` - Stores all blocks, but finalized states are pruned.
+* `archive` - Stores all blocks and states.
 
 The default is `prune`.
 

--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -190,7 +190,7 @@ is specified using [`--data-base-path`](#data-base-path-data-path).
 
 Set the frequency (in slots) at which to store finalized states to disk. The default is 2048.
 
-This option is ignored if [`--data-storage-mode`](#data-storage-mode) is set to `prune`.
+This option is ignored if [`--data-storage-mode`](#data-storage-mode) is not set to `archive`.
 
 !!! note
     Specifying a larger number of slots as the archive frequency has a potentially higher overhead
@@ -229,7 +229,12 @@ This option is ignored if [`--data-storage-mode`](#data-storage-mode) is set to 
     data-storage-mode: "archive"
     ```
 
-Set the strategy for handling historical chain data. Valid options are `prune` and `archive`.
+Set the strategy for handling historical chain data. Valid options are:
+
+ * `minimal` - Stores the minimal required data to follow the chain and run validators. Finalized states and historic blocks are pruned.
+ * `prune` - Stores all blocks, but finalized states are pruned.
+ * `archive` - Stores all blocks and states.
+
 The default is `prune`.
 
 ### data-storage-non-canonical-blocks-enabled

--- a/docs/Reference/CLI/Subcommands/Admin.md
+++ b/docs/Reference/CLI/Subcommands/Admin.md
@@ -167,7 +167,7 @@ This option is ignored if [`--data-storage-mode`](#data-storage-mode) is set to 
     data-storage-mode: "archive"
     ```
 
-Set the strategy for handling historical chain data. Valid options are `prune` and `archive`.
+Set the strategy for handling historical chain data. Valid options are `minimal`, `prune` and `archive`.
 The default is `prune`.
 
 #### `data-validator-path`


### PR DESCRIPTION
## Describe the change
Adds the new `MINIMAL` value for the `--data-storage-mode` CLI option. Provides an explanation of the data stored for each mode.

## Issue fixed
https://github.com/ConsenSys/teku/issues/6576

## Impacted parts

<!-- Check the item from the following lists that your PR impacts. You can check multiple boxes. -->

For content changes:

- [x] Documentation content
- [ ] Documentation page organization

For tool changes:

- [ ] CircleCI workflow
- [ ] Build and QA tools (for example lint or vale)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] Read the Docs configuration
- [ ] GitHub integration

## After creating your PR and tests have finished

Make sure that:

- [ ] You've [fixed any issues](https://consensys.net/docs/doctools/en/latest/contribute/fix-cicd-errors/) raised by the tests.
- [ ] You've [previewed your changes on Read the Docs](https://consensys.net/docs/doctools/en/latest/preview/old-system/#preview-on-read-the-docs)
  and added a [preview link](#preview).

## Preview

<!-- Add the link to preview your changes on Read the Docs.

The link format is "https://pegasys-teku--{your PR number}.org.readthedocs.build/en/{your PR number}/",
where {your PR number} is replaced by the number of this PR.
-->
