### PR TITLE
Replace reference to Infura initial state endpoints

### DIFF
--- a/docs/HowTo/Get-Started/Checkpoint-Start.md
+++ b/docs/HowTo/Get-Started/Checkpoint-Start.md
@@ -29,7 +29,6 @@ to download the finalized checkpoint state from the
 on the beacon node (for example, Teku).
 
 !!! note
-
     You can also download a finalized checkpoint state file, and specify the location
     using the [`--initial-state`](../../Reference/CLI/CLI-Syntax.md#initial-state) option. To
     download the file and name it `state.ssz` run:
@@ -37,9 +36,9 @@ on the beacon node (for example, Teku).
     ```bash
     curl -o state.ssz -H 'Accept: application/octet-stream' http://other-node:5051/eth/v2/debug/beacon/states/finalized
     ```
-    [Infura](https://infura.io/) provides initial state endpoints for free.
-    Registration to Infura services is required.
-    Watch the ["Teku Snapshot Sync from Infura" video](https://youtu.be/ce9uVRl23zI) for more details.
+
+!!! tip
+    See [this community-maintained list of checkpoint state endpoints](https://eth-clients.github.io/checkpoint-sync-endpoints/).
 
 <!--links-->
 [REST API enabled]: ../../Reference/CLI/CLI-Syntax.md#rest-api-enabled

--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -558,9 +558,7 @@ using the [`--network`](#network) option.
     file at each restart.
 
 !!! tip
-
-    [Infura](https://infura.io/) can be used as the source of initial states with
-    `--initial-state https://{projectid}:{secret}@eth2-beacon-mainnet.infura.io/eth/v2/debug/beacon/states/finalized`
+    See [this community-maintained list of checkpoint state endpoints](https://eth-clients.github.io/checkpoint-sync-endpoints/).
 
 ### logging
 


### PR DESCRIPTION
Remove references to Infura providing initial state endpoints, and replace it with the community maintained list. Fixes #406.