### PR TITLE
Fix `besu_node` command array in docker-compose

### DIFF
--- a/docs/HowTo/Get-Started/Installation-Options/Run-Docker-Image.md
+++ b/docs/HowTo/Get-Started/Installation-Options/Run-Docker-Image.md
@@ -105,10 +105,10 @@ to start the container.
                   "--sync-mode=FAST",
                   "--rpc-http-enabled",
                   "--rpc-http-cors-origins=*",
-                  "--rpc-http-api=ETH,NET,CLIQUE,DEBUG,MINER,NET,PERM,ADMIN,EEA,TXPOOL,PRIV,WEB3"]
+                  "--rpc-http-api=ETH,NET,CLIQUE,DEBUG,MINER,NET,PERM,ADMIN,EEA,TXPOOL,PRIV,WEB3",
                   "--engine-jwt-secret=/var/lib/besu/data/token.txt",
                   "--engine-host-allowlist=*",
-                  "--engine-rpc-enabled=true"
+                  "--engine-rpc-enabled=true"]
         volumes:
           - ./besu:/var/lib/besu/data
         ports:

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,3 +25,5 @@ You can:
 * [Run Teku from a Docker image.](HowTo/Get-Started/Installation-Options/Run-Docker-Image.md)
 * [Install the binary distribution.](HowTo/Get-Started/Installation-Options/Install-Binaries.md)
 * [Build from source.](HowTo/Get-Started/Installation-Options/Build-From-Source.md)
+
+[//]: # (Debugging comment)

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,5 +25,3 @@ You can:
 * [Run Teku from a Docker image.](HowTo/Get-Started/Installation-Options/Run-Docker-Image.md)
 * [Install the binary distribution.](HowTo/Get-Started/Installation-Options/Install-Binaries.md)
 * [Build from source.](HowTo/Get-Started/Installation-Options/Build-From-Source.md)
-
-[//]: # (Debugging comment)


### PR DESCRIPTION
While trying to run the `docker-compose up` command I noticed that the commands for the `besu_node` doesn't have the correct syntax - the array was closing before the last command. 

This small fix moved the array closing bracket after the last command.
