### PR TITLE
Revert "Unhide DG detection option"

### DIFF
--- a/docs/HowTo/Doppelganger-Detection.md
+++ b/docs/HowTo/Doppelganger-Detection.md
@@ -15,18 +15,15 @@ When enabled, doppelganger detection is triggered from two entry points:
 
 :::warning
 
-Doppelganger detection is an early access feature. This feature is imperfect and might fail to detect doppelgangers. Use this as a last resort option that might prevent validators from being slashed.
+Doppelganger detection is an **early access** feature. This feature is imperfect and might fail to detect doppelgangers. Use this as a last resort option that might prevent validators from being slashed.
 
 :::
 
 ## Enable doppelganger detection
 
-Enable doppelganger detection by setting the
-[`--doppelganger-detection-enabled`](../Reference/CLI/CLI-Syntax.md#doppelganger-detection-enabled)
-option to `true`.
+Enable doppelganger detection by setting the `--Xdoppelganger-detection-enabled` option to `true`.
 
-Your validator client must be connected to a beacon node with validator liveness tracking enabled.
-Enable validator liveness tracking by setting the `--Xbeacon-liveness-tracking-enabled` option to `true`.
+Your validator client must be connected to a beacon node with liveness tracking enabled. Enable liveness tracking by setting the `--Xbeacon-liveness-tracking-enabled` option to `true`.
 
 ## Side effects
 

--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -322,38 +322,6 @@ data-validator-path: "/home/me/me_validator"
 
 Path to the validator client data. The default is `<data-base-path>/validator` where `<data-base-path>` is specified using [`--data-base-path`](#data-base-path-data-path).
 
-### doppelganger-detection-enabled
-
-<!--tabs-->
-
-# Syntax
-
-```bash
---doppelganger-detection-enabled[=<BOOLEAN>]
-```
-
-# Example
-
-```bash
---doppelganger-detection-enabled=true
-```
-
-# Environment variable
-
-```bash
-TEKU_DOPPELGANGER_DETECTION_ENABLED=true
-```
-
-# Configuration file
-
-```bash
-doppelganger-detection-enabled: true
-```
-
-<!--/tabs-->
-
-Enables or disables [doppelganger detection](../../HowTo/Doppelganger-Detection.md). The default is `false`.
-
 ### ee-endpoint
 
 <!--tabs-->


### PR DESCRIPTION
Due to a last minute change we'd like to revert this PR (We will raise a new one later)