### PR TITLE
edit withdrawals content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .vercel
+.idea

--- a/docs/Concepts/Withdrawals.md
+++ b/docs/Concepts/Withdrawals.md
@@ -6,49 +6,92 @@ sidebar_position: 8
 
 # Withdrawals
 
-Validators staking ether on Mainnet after [The Merge](Merge.md), accrue 2 forms of rewards:
+Validators staking ether on Mainnet after [The Merge](Merge.md), accrue two
+forms of rewards:
 
 - Execution layer rewards paid directly to a withdrawal address (Ethereum address).
 - Consensus layer rewards for performing actions each epoch.
 
-The [Capella network upgrade](https://notes.ethereum.org/@launchpad/withdrawals-faq#Q-What-is-ShanghaiCapella) implements an automated process that allows a validator's rewards to be transferred from the consensus layer to an Ethereum address on the execution layer. Before the Capella upgrade, consensus layer rewards were locked, and unable to be transferred to an Ethereum address.
+The
+[Capella network upgrade](https://notes.ethereum.org/@launchpad/withdrawals-faq#Q-What-is-ShanghaiCapella)
+implements an automated process that allows a validator's rewards to be
+transferred from the consensus layer to an Ethereum address on the execution layer.
+Before the Capella upgrade, consensus layer rewards were locked, and couldn't be
+transferred to an Ethereum address.
 
-:::warning
+:::caution
 
-When you create a validator, it's possible to set its withdrawal address to a [BLS address](https://en.wikipedia.org/wiki/BLS_digital_signature), or an Ethereum address. Withdrawal keys that are configured as BLS keys cannot have automated withdrawals executed for them.
+When you create a validator, you can set its withdrawal address to a
+[BLS address](https://en.wikipedia.org/wiki/BLS_digital_signature), or an
+Ethereum address.
+Withdrawal keys configured as BLS keys can't have automated withdrawals executed
+for them.
 
-You can [update your BLS withdrawal address to an Ethereum address](../HowTo/Withdrawal-Keys.md) after the Capella upgrade.
+You can
+[update your BLS withdrawal address to an Ethereum address](../HowTo/Withdrawal-Keys.md)
+after the Capella upgrade.
 
 :::
 
-You do not pay gas fees for receiving reward payments.
+You don't pay gas fees for receiving reward payments.
 
 ## Types of withdrawals
 
-Two types of automated withdrawals occur once the withdrawal key is set up as an Ethereum address: [partial withdrawals](#partial-withdrawals) and [full withdrawals](#full-withdrawals).
+Two types of automated withdrawals occur once the withdrawal key is set up as an
+Ethereum address: [partial withdrawals](#partial-withdrawals) and
+[full withdrawals](#full-withdrawals).
 
 ### Partial withdrawals
 
-Partial withdrawals are for active validators that have a balance exceeding 32 ETH. The network periodically makes transfers to the associated Ethereum address for validators with a balance exceeding 32 ETH. This means that a validator's balance will periodically reduce to 32 ETH once Capella becomes the active fork on the network.
+Partial withdrawals are for active validators that have a balance exceeding 32 ETH.
+The network periodically makes transfers to the associated Ethereum address for
+validators with a balance exceeding 32 ETH.
+This means that a validator's balance periodically reduces to 32 ETH once
+Capella becomes the active fork on the network.
 
 ### Full withdrawals
 
-Full withdrawals are for validators that have exited the network, and have waited the necessary time to withdraw their funds. For these validators, their entire balance is returned to the Ethereum address associated with the validator key. The balance cannot be transferred until the validator key is associated with an Ethereum address.
+Full withdrawals are for validators that have exited the network, and have
+waited the necessary time to withdraw their funds.
+For these validators, their entire balance is returned to the Ethereum address
+associated with the validator key.
+The balance can't be transferred until the validator key is associated with an
+Ethereum address.
 
-An exited validator cannot become active on the network again, and currently (as of Capella), there is no mechanism for recycling the validator ID that has been exited.
+An exited validator can't become active on the network again, and currently (as
+of Capella), there's no mechanism for recycling the validator ID that has been exited.
 
 ## How it works
 
-From the first Capella slot, block proposers provide up to 16 withdrawals per proposed block.
+From the first Capella slot, block proposers provide up to 16 withdrawals per
+proposed block.
 
-Proposers start from validator 1, and find validators that qualify: must have an Ethereum address as a withdrawal address, must have an excess balance, or have exited.
+Proposers start from validator 1, and find validators that qualify: must have an
+Ethereum address as a withdrawal address, must have an excess balance, or have exited.
 
-Block proposers select the withdrawals that go into the block. In each block, up to 16 changes to withdrawal credentials are also allowed, where an owner of a validator key can [update their withdrawal key's Ethereum address](../HowTo/Withdrawal-Keys.md). This update is retrieved from a pool, and the order is not guaranteed.
+Block proposers select the withdrawals that go into the block.
+In each block, up to 16 changes to withdrawal credentials are also allowed,
+where an owner of a validator key can
+[update their withdrawal key's Ethereum address](../HowTo/Withdrawal-Keys.md).
+This update is retrieved from a pool, and the order isn't guaranteed.
 
 ## Withdrawal keys
 
-Withdrawal keys that are configured as [BLS keys](https://en.wikipedia.org/wiki/BLS_digital_signature) cannot have automated withdrawals executed for them. Users must alter their credentials to specify an Ethereum address for their withdrawal key.
+Withdrawal keys configured as
+[BLS keys](https://en.wikipedia.org/wiki/BLS_digital_signature) can't have
+automated withdrawals executed for them.
+Users must alter their credentials to specify an Ethereum address for their
+withdrawal key.
 
-BLS withdrawal keys are prefixed with `0x00`, whereas Ethereum withdrawal keys are prefixed with a `0x01`.
+BLS withdrawal keys are prefixed with `0x00`, whereas Ethereum withdrawal keys
+are prefixed with `0x01`.
 
-To determine the type of withdrawal key used by your validator, you can [query your validator configuration onchain](../HowTo/Withdrawal-Keys.md#determine-the-withdrawal-key-type).
+To determine the type of withdrawal key your validator uses, you can
+[query your validator configuration onchain](../HowTo/Withdrawal-Keys.md#determine-the-withdrawal-address-type).
+
+:::caution
+
+Don't store your [validator keys](../HowTo/External-Signer/Manage-keys.md) and
+withdrawal keys in the same location.
+
+:::

--- a/docs/HowTo/External-Signer/Manage-keys.md
+++ b/docs/HowTo/External-Signer/Manage-keys.md
@@ -6,17 +6,28 @@ sidebar_position: 2
 
 # Manage validator signing keys
 
-You can manage the signing keys of validators using the [key manager API endpoints](https://ethereum.github.io/keymanager-APIs/). You can list keys, import keystores, and delete keys with the API.
+You can manage the signing keys of validators using the
+[key manager API endpoints](https://ethereum.github.io/keymanager-APIs/).
+You can list keys, import keystores, and delete keys with the API.
 
 ## Enable validator client API
 
-To use the key manager API endpoints, [enable the validator client API](../../Reference/Rest_API/Rest.md#enable-the-validator-client-api) using the [`--validator-api-enabled`](../../Reference/CLI/CLI-Syntax.md#validator-api-enabled) option. You must also [create a keystore](#create-a-keystore) to enable access.
+To use the key manager API endpoints,
+[enable the validator client API](../../Reference/Rest_API/Rest.md#enable-the-validator-client-api)
+using the [`--validator-api-enabled`](../../Reference/CLI/CLI-Syntax.md#validator-api-enabled)
+option.
+You must also [create a keystore](#create-a-keystore) to enable access.
 
 ### Create a keystore
 
 When enabling the validator client API, you must create a keystore.
 
-1.  Use a tool such as [keytool](https://docs.oracle.com/javase/6/docs/technotes/tools/solaris/keytool.html) or [openSSL](https://www.openssl.org/) to generate a keystore. Note that the `CN` value must be set to the domain name or IP used to access the validator API. Keytool sets this based on the answer to `What is your first and last name?`.
+1. Use a tool such as
+    [keytool](https://docs.oracle.com/javase/6/docs/technotes/tools/solaris/keytool.html)
+    or [openSSL](https://www.openssl.org/) to generate a keystore.
+    Note that the `CN` value must be set to the domain name or IP used to access
+    the validator API.
+    Keytool sets this based on the answer to `What is your first and last name?`.
 
     <!--tabs-->
 
@@ -34,19 +45,36 @@ When enabling the validator client API, you must create a keystore.
 
     <!--/tabs-->
 
-2.  Create a plain text file (for example `validator_keystore_pass.txt`) that stores the password you defined in the keystore.
+2. Create a plain text file (for example, `validator_keystore_pass.txt`) that
+    stores the password you defined in the keystore.
 
-3.  Start Teku using [`--validator-api-keystore-file`](../../Reference/CLI/CLI-Syntax.md#validator-api-keystore-file) to define the keystore file and [`--validator-api-keystore-password-file`](../../Reference/CLI/CLI-Syntax.md#validator-api-keystore-password-file) to define the password file.
+3. Start Teku using
+    [`--validator-api-keystore-file`](../../Reference/CLI/CLI-Syntax.md#validator-api-keystore-file)
+    to define the keystore file and
+    [`--validator-api-keystore-password-file`](../../Reference/CLI/CLI-Syntax.md#validator-api-keystore-password-file)
+    to define the password file.
 
     ```bash title="Example"
     teku --validator-api-enabled --validator-api-keystore-file=validator_keystore.p12 --validator-api-keystore-password-file=validator_keystore_pass.txt
     ```
 
-#### Supporting Multiple Domains and IPs
+:::caution
 
-When the key manager API is accessible via different domain names or IP addresses, each domain or IP needs to be listed in the SSL certificate to be accepted as valid. Multiple addresses can be specified when using openSSL to generate the certificate.
+Don't store your validator keys and
+[withdrawal keys](../../Concepts/Withdrawals.md#withdrawal-keys) in the same
+location.
 
-1.  Create a file named `openssl.cnf` containing the configuration required for the certificate.
+:::
+
+#### Support multiple domains and IPs
+
+When the key manager API is accessible using different domain names or IP
+addresses, each domain or IP must be listed in the SSL certificate to be
+accepted as valid.
+Multiple addresses can be specified when using openSSL to generate the certificate.
+
+1. Create a file named `openssl.cnf` containing the configuration required for
+    the certificate.
 
     ```ini title="openssl.cnf"
     [req]
@@ -74,11 +102,14 @@ When the key manager API is accessible via different domain names or IP addresse
     IP.2 = 10.0.0.6
     ```
 
-    You should adjust the `req_distinguised_name` and `alt_names` sections to match your needs.
+    You should adjust the `req_distinguised_name` and `alt_names` sections to
+    match your needs.
 
-2.  Create a plain text file (for example, `validator_keystore_pass.txt`) that stores the password you defined in the keystore.
+2. Create a plain text file (for example, `validator_keystore_pass.txt`) that
+    stores the password you defined in the keystore.
 
-3.  Generate an x509 certificate from the configuration and convert it to PKCS12 format:
+3. Generate an x509 certificate from the configuration and convert it to PKCS12
+    format:
 
     <!--tabs-->
 
@@ -100,7 +131,11 @@ When the key manager API is accessible via different domain names or IP addresse
 
 Authentication verifies user access to requested validator client methods.
 
-Upon startup of the validator client, Teku creates an API token at the path `/opt/teku/data/validator/key-manager`. When calling an endpoint that requires authorization, you must send the generated token in the `Authorization` request header field with the `Bearer` authentication scheme.
+Upon startup of the validator client, Teku creates an API token at the path
+`/opt/teku/data/validator/key-manager`.
+When calling an endpoint that requires authorization, you must send the
+generated token in the `Authorization` request header field with the `Bearer`
+authentication scheme.
 
 ```bash title="Example"
 curl -H "Authorization: Bearer <TOKEN>" -X GET https://localhost:5052/eth/v1/keystores

--- a/docs/HowTo/Withdrawal-Keys.md
+++ b/docs/HowTo/Withdrawal-Keys.md
@@ -6,18 +6,23 @@ sidebar_position: 14
 
 # Update your withdrawal credentials
 
-When you create a validator, it’s possible to set its [withdrawal](../Concepts/Withdrawals.md) address to a BLS address, or an Ethereum address.
+When you create a validator, it’s possible to set its
+[withdrawal](../Concepts/Withdrawals.md) address to a BLS address, or an
+Ethereum address.
 
-You can update your BLS withdrawal address to an Ethereum address after the Capella upgrade.
+You can update your BLS withdrawal address to an Ethereum address after the
+Capella upgrade.
 
 ## Determine the withdrawal address type
 
 **Prerequisites**:
 
-- Access to the beacon node API endpoint. By default this is `localhost:5051`
-- Install [`curl`](https://curl.se/) and [`jq`](https://stedolan.github.io/jq/)
+- Access to the beacon node API endpoint.
+  The default is `localhost:5051`.
+- [`curl`](https://curl.se/) and [`jq`](https://stedolan.github.io/jq/) installed.
 
-The following shell script allows you to determine the withdrawal address of a given validator ID.
+The following shell script allows you to determine the withdrawal address of a
+given validator ID.
 
 <!--tabs-->
 
@@ -36,44 +41,80 @@ curl http://localhost:5051/eth/v1/beacon/states/finalized/validators/$VALIDATOR 
 
 <!--/tabs-->
 
-In the script, specify the `<VALIDATOR_INDEX>` (for example `1`) that was provided when you joined the network. Alternatively you can specify the validator's public key.
+In the script, specify the `<VALIDATOR_INDEX>` (for example, `1`) that was
+provided when you joined the network.
+Alternatively, you can specify the validator's public key.
 
-In the output, the first 4 characters of the string, in this case `0x00`, indicates the key is a BLS withdrawal key.
+In the output, the first four characters of the string, in this case `0x00`,
+indicates the key is a BLS withdrawal key.
 
 ## Update your withdrawal address
 
-### From a BLS withdrawal address to an Ethereum address
+:::caution
 
-:::warning
-
-Teku does not offer functionality to create a signed withdrawal credential change. Tools such as [`ethdo`](https://github.com/wealdtech/ethdo/blob/master/docs/changingwithdrawalcredentials.md) allow you to generate this signed message, which can be submitted directly to your beacon node if your REST API is active.
+Don't store your [validator keys](External-Signer/Manage-keys.md) and withdrawal
+keys in the same location.
 
 :::
 
-If your withdrawal address is a BLS key (starts with `0x00`), the Capella fork provides a process to update your withdrawal address to a `0x01` withdrawal key (Ethereum address). You must have the BLS withdrawal address private key, or the seed phrase (mnemonic) to sign the request to prove that you have access to the BLS withdrawal key.
+### From a BLS withdrawal address to an Ethereum address
 
-Tools such as [ethdo](https://github.com/wealdtech/ethdo/blob/master/docs/changingwithdrawalcredentials.md) are able to sign the request correctly, and the signed data can be submitted directly, or via your own beacon node.
+:::caution
 
-:::warning Important information about changing withdrawal credentials
+Teku doesn't offer functionality to create a signed withdrawal credential change.
+Tools such as
+[`ethdo`](https://github.com/wealdtech/ethdo/blob/master/docs/changingwithdrawalcredentials.md)
+allow you to generate this signed message, which can be submitted directly to
+your beacon node if your REST API is active.
 
-- Once a validator has been updated to use a `0x01` withdrawal key (Ethereum address), it cannot be changed again.
-- Updating your withdrawal credentials is not available until the Capella fork is active.
+:::
+
+If your withdrawal address is a BLS key (starts with `0x00`), the Capella fork
+provides a process to update your withdrawal address to a `0x01` withdrawal key
+(Ethereum address).
+You must have the BLS withdrawal address private key, or the seed phrase
+(mnemonic) to sign the request to prove that you have access to the BLS
+withdrawal key.
+
+Tools such as
+[ethdo](https://github.com/wealdtech/ethdo/blob/master/docs/changingwithdrawalcredentials.md)
+can sign the request correctly, and the signed data can be submitted directly,
+or using your own beacon node.
+
+:::caution Important information about changing withdrawal credentials
+
+- Once you update a validator to use a `0x01` withdrawal key (Ethereum address),
+  you can't change it again.
+- Updating your withdrawal credentials isn't available until the Capella fork is
+  active.
 - Ensure you update to the expected Ethereum address because the change is permanent.
 
 :::
 
-A maximum of 16 validator keys can update their withdrawal credentials per block, so the process may be congested initially. If you submit a request to update your key, and it hasn't been done in a period of time, you might consider re-submitting the request. It may take several epochs for the change to be included in a block, depending on the number of requests in the queue.
+A maximum of 16 validator keys can update their withdrawal credentials per
+block, so the process may be congested initially.
+If you submit a request to update your key, and it hasn't been done in a period
+of time, you might consider re-submitting the request.
+It might take several epochs for the change to be included in a block, depending
+on the number of requests in the queue.
 
-Query the [`bls_to_execution_changes`](https://consensys.github.io/teku/#tag/Beacon/operation/getBlsToExecutionChanges) API see if your request is still in the pool.
+Query the
+[`bls_to_execution_changes`](https://consensys.github.io/teku/#tag/Beacon/operation/getBlsToExecutionChanges)
+API see if your request is still in the pool.
 
 ### Update your Ethereum address
 
-If your withdrawal credentials are set to an Ethereum address, and you wish to update it to a different address, you'll need to create a new validator key. You can exit your current validator key as a voluntary exit, and use the funds from the full withdrawal of that to create the new validator key.
+If your withdrawal credentials are set to an Ethereum address, and you wish to
+update it to a different address, you must create a new validator key.
+You can exit your current validator key as a voluntary exit, and use the funds
+from the full withdrawal of that to create the new validator key.
 
-The voluntary exit process takes while to complete, and the exiting validator must remain active during that time to avoid inactivity penalties.
+The voluntary exit process takes while to complete, and the exiting validator
+must remain active during that time to avoid inactivity penalties.
 
-:::warning
+:::caution
 
-Ensure that you own the current Ethereum address before exiting, otherwise you will be unable to access your funds.
+Ensure that you own the current Ethereum address before exiting, otherwise you
+can't access your funds.
 
 :::


### PR DESCRIPTION
Add notes that the user shouldn't store withdrawal keys and validator keys in the same location.
Minor edits to affected pages.

fixes #427 