### PR TITLE
docs: update macos requirements

### DIFF
--- a/docs/HowTo/Get-Started/Installation-Options/Install-Binaries.md
+++ b/docs/HowTo/Get-Started/Installation-Options/Install-Binaries.md
@@ -55,7 +55,7 @@ bin\teku --help
 
 :::caution
 
-Teku requires Java 11+ to run. Earlier versions are not supported. You can install Java using `brew cask install adoptopenjdk`. Alternatively, you can manually install the [Java JDK](https://www.oracle.com/java/technologies/javase-downloads.html).
+Teku requires Java 11+ to run. Earlier versions are not supported. You can install Java using `brew install temurin`. Alternatively, you can manually install the [Java JDK](https://www.oracle.com/java/technologies/javase-downloads.html).
 
 :::
 


### PR DESCRIPTION
fixes several issues

$ brew cask install adoptopenjdk
Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.

$ brew install adoptopenjdk
==> Caveats
Temurin is the official successor to this software:

  brew install --cask temurin

adoptopenjdk has been officially discontinued upstream. It may stop working correctly (or at all) in recent versions of macOS.

# Pull request checklist

Use the following template to make sure your PR fits the Teku documentation standard.

## Before creating the PR

Make sure that:

- [ ] You've read the [contribution guidelines](https://consensys.net/docs/doctools/).
- [ ] You've [previewed your changes locally](https://consensys.net/docs/doctools/en/latest/preview/old-system/#preview-locally).

## Describe the change

<!-- Add a clear and concise description of what your PR changes in the documentation. -->

## Issue fixed

<!-- Link to the GitHub issue that your PR addresses.

Add "fixes #{your issue number}" to close the issue automatically when the PR is merged.

If your PR doesn't completely fix the issue, add "see #{your issue number}" to link to the issue
without automatically closing it. -->

## Impacted parts

<!-- Check the item from the following lists that your PR impacts. You can check multiple boxes. -->

For content changes:

- [ ] Documentation content
- [ ] Documentation page organization

For tool changes:

- [ ] CircleCI workflow
- [ ] Build and QA tools (for example lint or vale)
- [ ] Node dependencies and JavaScript
- [ ] Read the Docs configuration
- [ ] GitHub integration

## After creating your PR and tests have finished

Make sure that:

- [ ] You've [fixed any issues](https://consensys.net/docs/doctools/en/latest/contribute/fix-cicd-errors/) raised by the tests.
- [ ] You've previewed your changes with Vercel below.

## Preview

<!-- Add the link to preview your changes on Read the Docs.

The link format is "https://pegasys-teku--{your PR number}.org.readthedocs.build/en/{your PR number}/",
where {your PR number} is replaced by the number of this PR.
-->
