### PR TITLE
add external-signer value to validators-external-signer-public-keys

### DIFF
--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -2677,10 +2677,16 @@ validators-external-signer-public-keys: ["0xa99a...e44c","0xb89b...4a0b"]
 
 List or URL of validator public keys used by an external signer (for example, Web3Signer).
 
-Use the URL of the external signer's [`/publicKeys` endpoint](https://consensys.github.io/web3signer/web3signer-eth2.html#tag/Public-Key) to load the public keys of all registered validators. For example:
+Use the URL to load the public keys from a remote service. For example:
 
 ```bash
---validators-external-signer-public-keys=http://localhost:9000/api/v1/eth2/publicKeys
+--validators-external-signer-public-keys=http://localhost:9900/publicKeys
+```
+
+Use the value `external-signer` to load all public keys managed by the external signer. Teku will automatically query external signer's [`/publicKeys` endpoint](https://consensys.github.io/web3signer/web3signer-eth2.html#tag/Public-Key).
+
+```bash
+--validators-external-signer-public-keys=external-signer
 ```
 
 :::tip


### PR DESCRIPTION
This is related to https://github.com/Consensys/teku/pull/7325
Does it worth to be mentioned in the validator-client subcommand https://docs.teku.consensys.net/reference/cli/subcommands/validator-client too?