### PR TITLE
Removing documentation for deprecated exchange-capabilities-enabled option

### DIFF
--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -671,37 +671,6 @@ Normally, at sync, Teku requests all deposit logs from the execution layer up to
 If a malicious peer changes the bundled tree, Teku throws `InvalidDepositEventsException` on the next deposit received from the execution layer. The malicious peer can't follow up the chain, and so can't propose with an incorrect deposit tree snapshot.
 :::
 
-### exchange-capabilities-enabled
-
-<!--tabs-->
-
-# Syntax
-
-```bash
---exchange-capabilities-enabled[=<BOOLEAN>]
-```
-
-# Example
-
-```bash
---exchange-capabilities-enabled=true
-```
-
-# Environment variable
-
-```bash
-TEKU_EXCHANGE_CAPABILITIES_ENABLED=true
-```
-
-# Configuration file
-
-```bash
-exchange-capabilities-enabled: true
-```
-
-<!--/tabs-->
-
-Enables or disables Engine API method negotiation. Using this option simplifies the process of upgrading nodes, allowing the beacon node to know what Engine API methods the [execution client](../../concepts/merge.md#execution-clients) supports. The default is `true`.
 
 ### genesis-state
 


### PR DESCRIPTION
This reverts commit c1d3c9b65c6190fed03feb76ccf14c102c6e0903.
