### PR TITLE
Add lukso as a network option

### DIFF
--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -1360,9 +1360,10 @@ Possible values are:
 | `mainnet` | Consensus layer | Production | Main network |
 | `minimal` | Consensus layer | Test | Used for local testing and development networks |
 | `goerli` | Consensus layer | Test | Multi-client testnet |
-| `gnosis` | Consensus layer | Production | Network for the [Gnosis chain](https://docs.gnosischain.com/) |
+| `gnosis` | Consensus layer | Production | Network for the [Gnosis chain](https://www.gnosis.io/) |
 | `sepolia` | Consensus layer | Test | Multi-client testnet |
 | `chiado` | Consensus layer | Test | Gnosis [testnet](https://docs.gnosischain.com/about/networks/chiado/) |
+| `lukso` | Consensus layer | Production | Network for the [Lukso chain](https://lukso.network/) |
 
 Predefined networks can provide defaults such as the initial state of the network, bootnodes, and the address of the deposit contract.
 

--- a/docs/reference/cli/subcommands/admin.md
+++ b/docs/reference/cli/subcommands/admin.md
@@ -288,8 +288,10 @@ Possible values are:
 | `mainnet` | Consensus layer | Production | Main network |
 | `minimal` | Consensus layer | Test | Used for local testing and development networks |
 | `goerli` | Consensus layer | Test | Multi-client testnet |
-| `gnosis` | Consensus layer | Production | Network for the [Gnosis chain](https://docs.gnosischain.com/) |
+| `gnosis` | Consensus layer | Production | Network for the [Gnosis chain](https://www.gnosis.io/) |
 | `sepolia` | Consensus layer | Test | Multi-client testnet |
+| `chiado` | Consensus layer | Test | Gnosis [testnet](https://docs.gnosischain.com/about/networks/chiado/) |
+| `lukso` | Consensus layer | Production | Network for the [Lukso chain](https://lukso.network/) |
 
 Predefined networks can provide defaults such the initial state of the network, bootnodes, and the address of the deposit contract.
 
@@ -570,7 +572,9 @@ Possible values are:
 | `mainnet` | Consensus layer | Production | Main network |
 | `minimal` | Consensus layer | Test | Used for local testing and development networks |
 | `goerli` | Consensus layer | Test | Multi-client testnet |
-| `gnosis` | Consensus layer | Production | Network for the [Gnosis chain](https://docs.gnosischain.com/) |
+| `gnosis` | Consensus layer | Production | Network for the [Gnosis chain](https://www.gnosis.io/) |
 | `sepolia` | Consensus layer | Test | Multi-client testnet |
+| `chiado` | Consensus layer | Test | Gnosis [testnet](https://docs.gnosischain.com/about/networks/chiado/) |
+| `lukso` | Consensus layer | Production | Network for the [Lukso chain](https://lukso.network/) |
 
 Predefined networks can provide defaults such the initial state of the network, bootnodes, and the address of the deposit contract.

--- a/docs/reference/cli/subcommands/migrate-database.md
+++ b/docs/reference/cli/subcommands/migrate-database.md
@@ -157,5 +157,7 @@ Possible values are:
 | `mainnet` | Consensus layer | Production | Main network |
 | `minimal` | Consensus layer | Test | Used for local testing and development networks |
 | `goerli` | Consensus layer | Test | Multi-client testnet |
-| `gnosis` | Consensus layer | Production | Network for the [Gnosis chain](https://docs.gnosischain.com/) |
+| `gnosis` | Consensus layer | Production | Network for the [Gnosis chain](https://www.gnosis.io/) |
 | `sepolia` | Consensus layer | Test | Multi-client testnet |
+| `chiado` | Consensus layer | Test | Gnosis [testnet](https://docs.gnosischain.com/about/networks/chiado/) |
+| `lukso` | Consensus layer | Production | Network for the [Lukso chain](https://lukso.network/) |

--- a/docs/reference/cli/subcommands/slashing-protection.md
+++ b/docs/reference/cli/subcommands/slashing-protection.md
@@ -366,8 +366,10 @@ Possible values are:
 | `mainnet` | Consensus layer | Production | Main network |
 | `minimal` | Consensus layer | Test | Used for local testing and development networks |
 | `goerli` | Consensus layer | Test | Multi-client testnet |
-| `gnosis` | Consensus layer | Production | Network for the [Gnosis chain](https://docs.gnosischain.com/) |
+| `gnosis` | Consensus layer | Production | Network for the [Gnosis chain](https://www.gnosis.io/) |
 | `sepolia` | Consensus layer | Test | Multi-client testnet |
+| `chiado` | Consensus layer | Test | Gnosis [testnet](https://docs.gnosischain.com/about/networks/chiado/) |
+| `lukso` | Consensus layer | Production | Network for the [Lukso chain](https://lukso.network/) |
 
 Predefined networks can provide defaults such the initial state of the network, bootnodes, and the address of the deposit contract.
 

--- a/project-words.txt
+++ b/project-words.txt
@@ -287,6 +287,7 @@ longpaths
 lorber
 lowercased
 lqip
+lukso
 lunrjs
 mapbox
 marcey


### PR DESCRIPTION
As per https://github.com/Consensys/teku/pull/7380

+ edited `gnosis` link and added `chiado` to other required files as well.