### PR TITLE
Updated default data-storage-mode to minimal

### DIFF
--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -358,7 +358,7 @@ Set the strategy for handling historical chain data. Valid options are:
 - `prune` - Stores all blocks, but finalized states are pruned.
 - `archive` - Stores all blocks and states.
 
-The default is `prune`.
+The default is `minimal`.
 
 ### data-storage-non-canonical-blocks-enabled
 

--- a/docs/reference/cli/subcommands/admin.md
+++ b/docs/reference/cli/subcommands/admin.md
@@ -388,7 +388,7 @@ TEKU_DATA_BEACON_PATH=/home/me/me_beacon
 # Configuration file
 
 ```bash
-data-beacon-path: "/home/me/me_beaon"
+data-beacon-path: "/home/me/me_beacon"
 ```
 
 <!--/tabs-->
@@ -427,7 +427,7 @@ data-storage-archive-frequency: 1028
 
 Set the frequency (in slots) at which to store finalized states to disk. The default is 2048.
 
-This option is ignored if [`--data-storage-mode`](#data-storage-mode) is set to `prune`.
+This option is ignored if [`--data-storage-mode`](#data-storage-mode) is not set to `archive`.
 
 :::note
 
@@ -467,7 +467,7 @@ data-storage-mode: "archive"
 
 <!--/tabs-->
 
-Set the strategy for handling historical chain data. Valid options are `prune` and `archive`. The default is `prune`.
+Set the strategy for handling historical chain data. Valid options are `minimal`, `prune` and `archive`. The default is `minimal`.
 
 #### `data-validator-path`
 


### PR DESCRIPTION
Reflecting the changes from teku #7392.

The story is a little complicated because of the historic treatment of existing databases to default to 'prune' so they don't lose data, but the TL/DR; for new databases is they will default to minimal from now on, so reflected that in the documentation.