### PR TITLE
Fix description for p2p-subscribe-all-subnets-enabled

### DIFF
--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -1903,7 +1903,7 @@ p2p-subscribe-all-subnets-enabled: true
 
 Forces the beacon node to stay subscribed to all subnets regardless of the number of validators. The default is `false`.
 
-When set to `true` and running a low number of validators, Teku subscribes and unsubscribes from subnets as needed for the running validators.
+When set to `false` and running a low number of validators, Teku subscribes and unsubscribes from subnets as needed for the running validators.
 
 This option is primarily for users running an external validator client and load balancing it across multiple beacon nodes. Without this flag, depending on how requests are load balanced, the beacon nodes may not have subscribed to the required subnets and be unable to produce aggregates.
 

--- a/versioned_docs/version-23.6.2/reference/cli/index.md
+++ b/versioned_docs/version-23.6.2/reference/cli/index.md
@@ -1902,7 +1902,7 @@ p2p-subscribe-all-subnets-enabled: true
 
 Forces the beacon node to stay subscribed to all subnets regardless of the number of validators. The default is `false`.
 
-When set to `true` and running a low number of validators, Teku subscribes and unsubscribes from subnets as needed for the running validators.
+When set to `false` and running a low number of validators, Teku subscribes and unsubscribes from subnets as needed for the running validators.
 
 This option is primarily for users running an external validator client and load balancing it across multiple beacon nodes. Without this flag, depending on how requests are load balanced, the beacon nodes may not have subscribed to the required subnets and be unable to produce aggregates.
 


### PR DESCRIPTION
Hi team, I believe the description of this flag is currently not completely accurate and as a consequence, slightly confusing.