### PR TITLE
add non canonical blob sidecars storage

### DIFF
--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -390,7 +390,7 @@ data-storage-non-canonical-blocks-enabled: true
 
 <!--/tabs-->
 
-Specify whether to store non-canonical blocks. The default is `false`.
+Specify whether to store non-canonical blocks and blob sidecars. The default is `false`.
 
 ### data-validator-path
 


### PR DESCRIPTION
As per https://github.com/Consensys/teku/pull/7258, added non canonical blob sidecars to the `--data-storage-non-canonical-blocks-enabled` option description