### PR TITLE
Updated the peering section of troubleshooting

### DIFF
--- a/docs/how-to/troubleshoot/general.md
+++ b/docs/how-to/troubleshoot/general.md
@@ -3,7 +3,7 @@ description: Solve common problems encountered with Teku.
 sidebar_position: 14
 ---
 
-# Troubleshoot general issues
+# General issues
 
 ## Out of memory error
 

--- a/docs/how-to/troubleshoot/network.md
+++ b/docs/how-to/troubleshoot/network.md
@@ -70,10 +70,10 @@ View the [Prysm guide](https://docs.prylabs.network/docs/prysm-usage/p2p-host-ip
 
 ### Advertised IP address issues 
 
-A potential reason for incoming peers being unable to connect could be an incorrect address specified using the
+A possible reason for incoming peers being unable to connect could be an incorrect address specified using the
 [`--p2p-advertised-ip`](../../reference/cli/index.md#p2p-advertised-ip) option. Teku auto-detects the address to use by
 default, so most users won't need to use this option. If you're experiencing issues with incoming peers despite having
-correct firewall and forwarding settings, this could likely be the cause.
+correct firewall and forwarding settings, this could potentially be the cause.
 
 
 ### Network gateway issues


### PR DESCRIPTION
Needed to address some terminology and simplify some of the debugging of NAT port forwarding, hopefully this terminology will be more clear.

Added some CLI args into the troubleshooting, not sure if they should be links?

There's basically 3 sections (the 'another possible'... are different cases to assist), i'm not sure if they should be more clearly separate either but I figured i'd add them while i'm going...