### PR TITLE
506 versioning improvements

### DIFF
--- a/src/theme/DocVersionBadge/index.js
+++ b/src/theme/DocVersionBadge/index.js
@@ -1,4 +1,3 @@
-
 export default function DocVersionBadge({className}) {
   return null;
 }

--- a/src/theme/DocVersionBadge/index.js
+++ b/src/theme/DocVersionBadge/index.js
@@ -1,3 +1,3 @@
-export default function DocVersionBadge({className}) {
+export default function DocVersionBadge({ className }) {
   return null;
 }

--- a/src/theme/DocVersionBadge/index.js
+++ b/src/theme/DocVersionBadge/index.js
@@ -1,0 +1,4 @@
+
+export default function DocVersionBadge({className}) {
+  return null;
+}

--- a/src/theme/DocVersionBanner/index.jsx
+++ b/src/theme/DocVersionBanner/index.jsx
@@ -98,8 +98,6 @@ function DocVersionBannerEnabled({ className, versionMetadata }) {
       role="alert">
       <div>
         <BannerLabel siteTitle={siteTitle} versionMetadata={versionMetadata} />
-      </div>
-      <div className="margin-top--md">
         <LatestVersionSuggestionLabel
           versionLabel={latestVersionSuggestion.name}
           to={latestVersionSuggestedDoc.path}

--- a/src/theme/DocVersionBanner/index.jsx
+++ b/src/theme/DocVersionBanner/index.jsx
@@ -37,7 +37,7 @@ function UnmaintainedVersionLabel({ siteTitle, versionMetadata }) {
         versionLabel: <b>{versionMetadata.label}</b>,
       }}>
       {
-        "This is documentation for {siteTitle} {versionLabel}, which is no longer actively maintained."
+        "This is documentation for Teku version {versionLabel}, which is no longer actively maintained."
       }
     </Translate>
   );


### PR DESCRIPTION
This PR will close #506 

It will do the following:

1. Update the siteTitle variable to use the static value *Teku version*
2. Fix the line break in the unreleased banner
3. eject the `DocVersionBadge` and replace it with a custom component.