### PR TITLE
Add Chiado back to index table

### DIFF
--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -1652,6 +1652,7 @@ Possible values are:
 | `gnosis` | Consensus layer | Production | Network for the [Gnosis chain](https://www.gnosis.io/) |
 | `holesky` | Consensus layer | Test | Multi-client testnet |
 | `sepolia` | Consensus layer | Test | Multi-client testnet |
+| `chiado`  | Consensus layer | Test | Gnosis [testnet](https://docs.gnosischain.com/concepts/networks/chiado) |
 | `lukso` | Consensus layer | Production | Network for the [Lukso chain](https://lukso.network/) |
 
 Predefined networks can provide defaults such as the initial state of the network, bootnodes, and the address of the deposit contract.


### PR DESCRIPTION
Closes #

I removed the Chiado testnet in a [ previous PR](https://github.com/Consensys/doc.teku/pull/546) (I had difficulty finding the link - thanks @alexandratran  for providing). Adding it back in with this PR.  