### PR TITLE
Add  `p2p-direct-peers` CLI option

### DIFF
--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -241,7 +241,7 @@ If it can't download the finalized state, it tries to download the genesis state
 See [this community-maintained list of checkpoint state endpoints](https://eth-clients.github.io/checkpoint-sync-endpoints/).
 :::
 
-When this option is set, and `--deposit-snapshot-enabled` is also not set or disabled, 
+When this option is set, and `--deposit-snapshot-enabled` is also not set or disabled,
 the `--checkpoint-sync-url` value will be used to determine the deposit snapshot.
 
 ### `config-file`
@@ -504,7 +504,6 @@ data-validator-path: "/home/me/me_validator"
 
 Path to the validator client data. The default is `<data-base-path>/validator` where `<data-base-path>` is specified using [`--data-base-path`](#data-base-path-data-path).
 
-
 ### `deposit-snapshot-enabled`
 
 <Tabs>
@@ -659,7 +658,7 @@ ee-jwt-claim-id: "foobar"
 </Tabs>
 
 A unique identifier for the consensus layer client. When using the JSON-RPC API engine, this identifier is added to JWT claims as an `id` claim.
-  
+
 ### `ee-jwt-secret-file`
 
 <Tabs>
@@ -886,7 +885,7 @@ exit-when-no-validator-keys-enabled: true
 </Tabs>
 
 The default setting is `false`.
-If this option is set to `false`, Teku continues running even when no validator keys are loaded. 
+If this option is set to `false`, Teku continues running even when no validator keys are loaded.
 
 If this option is set to `true`, Teku automatically exits if no validator keys are loaded, or there are no active validators.
 
@@ -1385,7 +1384,7 @@ metrics-categories: ["BEACON", "JVM", "PROCESS"]
   </TabItem>
 </Tabs>
 
-Categories for which to track metrics. Options are `JVM`, `PROCESS`, `BEACON`, `DISCOVERY`, `EVENTBUS`, `EXECUTOR`, `LIBP2P`, `NETWORK`, `STORAGE`, `STORAGE_HOT_DB`, `STORAGE_FINALIZED_DB`, `REMOTE_VALIDATOR`, `VALIDATOR`, `VALIDATOR_PERFORMANCE`, `VALIDATOR_DUTY`.  All but `VALIDATOR_DUTY` categories are enabled by default.
+Categories for which to track metrics. Options are `JVM`, `PROCESS`, `BEACON`, `DISCOVERY`, `EVENTBUS`, `EXECUTOR`, `LIBP2P`, `NETWORK`, `STORAGE`, `STORAGE_HOT_DB`, `STORAGE_FINALIZED_DB`, `REMOTE_VALIDATOR`, `VALIDATOR`, `VALIDATOR_PERFORMANCE`, `VALIDATOR_DUTY`. All but `VALIDATOR_DUTY` categories are enabled by default.
 
 When `metrics-categories` is used, only the categories specified in this option are enabled (all other categories are disabled).
 
@@ -1644,16 +1643,16 @@ The default is `mainnet`.
 
 Possible values are:
 
-| Network | Chain | Type | Description |
-| :-- | :-- | :-- | :-- |
-| `mainnet` | Consensus layer | Production | Main network |
-| `minimal` | Consensus layer | Test | Used for local testing and development networks |
-| `goerli` | Consensus layer | Test | Multi-client testnet |
-| `gnosis` | Consensus layer | Production | Network for the [Gnosis chain](https://www.gnosis.io/) |
-| `holesky` | Consensus layer | Test | Multi-client testnet |
-| `sepolia` | Consensus layer | Test | Multi-client testnet |
-| `chiado`  | Consensus layer | Test | Gnosis [testnet](https://docs.gnosischain.com/concepts/networks/chiado) |
-| `lukso` | Consensus layer | Production | Network for the [Lukso chain](https://lukso.network/) |
+| Network   | Chain           | Type       | Description                                                             |
+| :-------- | :-------------- | :--------- | :---------------------------------------------------------------------- |
+| `mainnet` | Consensus layer | Production | Main network                                                            |
+| `minimal` | Consensus layer | Test       | Used for local testing and development networks                         |
+| `goerli`  | Consensus layer | Test       | Multi-client testnet                                                    |
+| `gnosis`  | Consensus layer | Production | Network for the [Gnosis chain](https://www.gnosis.io/)                  |
+| `holesky` | Consensus layer | Test       | Multi-client testnet                                                    |
+| `sepolia` | Consensus layer | Test       | Multi-client testnet                                                    |
+| `chiado`  | Consensus layer | Test       | Gnosis [testnet](https://docs.gnosischain.com/concepts/networks/chiado) |
+| `lukso`   | Consensus layer | Production | Network for the [Lukso chain](https://lukso.network/)                   |
 
 Predefined networks can provide defaults such as the initial state of the network, bootnodes, and the address of the deposit contract.
 
@@ -1764,6 +1763,44 @@ p2p-advertised-udp-port: 1789
 
 The advertised UDP port to external peers. The default is the port specified in [`--p2p-advertised-port`](#p2p-advertised-port) if it is set. Otherwise, the default is the port specified in [`--p2p-port`](#p2p-port).
 
+### `p2p-direct-peers`
+
+<Tabs>
+  <TabItem value="Syntax" label="Syntax" default>
+
+```bash
+--p2p-direct-peers=<ADDRESS>[,<ADDRESS>...]...
+```
+
+  </TabItem>
+  <TabItem value="Example" label="Example" >
+
+```bash
+--p2p-direct-peers=/ip4/151.150.191.80/tcp/9000/p2p/16Ui...aXRz,/ip4/151.150.191.80/tcp/9000/p2p/16Ui...q6f1
+```
+
+  </TabItem>
+  <TabItem value="Environment variable" label="Environment variable" >
+
+```bash
+TEKU_P2P_DIRECT_PEERS=/ip4/151.150.191.80/tcp/9000/p2p/16Ui...aXRz,/ip4/151.150.191.80/tcp/9000/p2p/16Ui...q6f1
+```
+
+  </TabItem>
+  <TabItem value="Configuration file" label="Configuration file" >
+
+```bash
+p2p-direct-peers: ["/ip4/151.150.191.80/tcp/9000/p2p/16Ui...aXRz",
+                    "/ip4/151.150.191.80/tcp/9000/p2p/16Ui...q6f1"]
+```
+
+  </TabItem>
+</Tabs>
+
+List of comma-separated [multiaddresses](https://docs.libp2p.io/concepts/appendix/glossary/#multiaddr) of direct peers
+with which to establish and maintain connections. Direct peers are static peers with which this node will always
+exchange full messages, regardless of peer scoring mechanisms. Such peers will also need to enable you as direct
+in order to work.
 
 ### `p2p-discovery-bootnodes`
 
@@ -1800,8 +1837,6 @@ p2p-discovery-bootnodes: ["enr:-Iu4QG...wgiMo",
 </Tabs>
 
 List of comma-separated Ethereum Node Records (ENRs) for P2P discovery bootstrap.
-
-
 
 ### `p2p-discovery-enabled`
 
@@ -2103,7 +2138,6 @@ p2p-port: 1789
 
 Specifies the P2P listening ports (UDP and TCP). The default is `9000`.
 
-
 ### `p2p-private-key-file`
 
 <Tabs>
@@ -2181,7 +2215,8 @@ p2p-static-peers: ["/ip4/151.150.191.80/tcp/9000/p2p/16Ui...aXRz",
   </TabItem>
 </Tabs>
 
-List of comma-separated [multiaddresses](https://docs.libp2p.io/concepts/appendix/glossary/#multiaddr) of static peers.
+List of comma-separated [multiaddresses](https://docs.libp2p.io/concepts/appendix/glossary/#multiaddr) of static peers
+with which to establish and maintain connections.
 
 ### `p2p-subscribe-all-subnets-enabled`
 
@@ -2918,7 +2953,6 @@ validator-api-port: 5052
 </Tabs>
 
 The [validator REST API](../rest.md#enable-the-validator-client-api) listening port (HTTP). The default is 5052.
-
 
 ### `validators-builder-registration-default-enabled`
 


### PR DESCRIPTION
This PR updates the reference section of the docs for the CLI, describing the new `p2p-direct-peers` option introduced in Teku with https://github.com/Consensys/teku/pull/8098.

Thank you!