### PR TITLE
update vercel redirects

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,12 +3,12 @@
   "redirects": [
     {
       "source": "/en/latest",
-      "destination": "/development/public-networks",
+      "destination": "/development/introduction",
       "permanent": true
     },
     {
       "source": "/en/latest/",
-      "destination": "/development/public-networks",
+      "destination": "/development/introduction",
       "permanent": true
     },
     {
@@ -33,12 +33,12 @@
     },
     {
       "source": "/development",
-      "destination": "/development/public-networks",
+      "destination": "/development/introduction",
       "permanent": true
     },
     {
       "source": "/:path(\\d*\\.\\d*\\.\\d*)",
-      "destination": "/:path*/public-networks",
+      "destination": "/:path*/introduction",
       "permanent": true
     }
   ]

--- a/vercel.json
+++ b/vercel.json
@@ -1,18 +1,44 @@
 {
   "cleanUrls": true,
   "redirects": [
-    { "source": "/en/latest", "destination": "/development", "permanent": true },
-    { "source": "/en/latest/", "destination": "/development", "permanent": true },
+    {
+      "source": "/en/latest",
+      "destination": "/development/public-networks",
+      "permanent": true
+    },
+    {
+      "source": "/en/latest/",
+      "destination": "/development/public-networks",
+      "permanent": true
+    },
     {
       "source": "/en/latest/:match(.*)",
       "destination": "/development/:match(.*)",
       "permanent": true
     },
-    { "source": "/en/stable", "destination": "/", "permanent": true },
-    { "source": "/en/stable/", "destination": "/", "permanent": true },
+    {
+      "source": "/en/stable",
+      "destination": "/",
+      "permanent": true
+    },
+    {
+      "source": "/en/stable/",
+      "destination": "/",
+      "permanent": true
+    },
     {
       "source": "/en/stable/:match(.*)",
       "destination": "/:match(.*)",
+      "permanent": true
+    },
+    {
+      "source": "/development",
+      "destination": "/development/public-networks",
+      "permanent": true
+    },
+    {
+      "source": "/:path(\\d*\\.\\d*\\.\\d*)",
+      "destination": "/:path*/public-networks",
       "permanent": true
     }
   ]


### PR DESCRIPTION
This PR adds redirects for versioned doc root paths and fixes existing vercel redirects.

Fixes #552 

## Preview

For example, in the current docs the following links do not redirect properly:
- https://docs.teku.consensys.io/24.3.0
- https://docs.teku.consensys.io/development
- https://docs.teku.consensys.io/en/latest

With the changes in the PR, they should redirect properly:
- https://doc-teku-qt91a6nl9-infura-web.vercel.app/24.3.0
- https://doc-teku-qt91a6nl9-infura-web.vercel.app/development
- https://doc-teku-qt91a6nl9-infura-web.vercel.app/en/latest