### PR TITLE
Removing references to Goerli (replacing with Holesky)

### DIFF
--- a/docs/get-started/connect/testnet.md
+++ b/docs/get-started/connect/testnet.md
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 # Connect to a testnet
 
 Run Teku as a consensus client with any execution client on a testnet (for example [Holesky](https://github.com/eth-clients/holesky) or
-[Sepolia](https://github.com/eth-clients/sepolia).
+[Sepolia](https://github.com/eth-clients/sepolia)).
 
 If you're using [Hyperledger Besu](https://besu.hyperledger.org/en/stable/) as an execution client, you can follow the
 [Besu and Teku testnet tutorial](https://besu.hyperledger.org/en/latest/public-networks/tutorials/besu-teku-testnet/).

--- a/docs/get-started/connect/testnet.md
+++ b/docs/get-started/connect/testnet.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 
 # Connect to a testnet
 
-Run Teku as a consensus client with any execution client on a testnet (for example [Goerli](https://github.com/eth-clients/goerli) or
+Run Teku as a consensus client with any execution client on a testnet (for example [Holesky](https://github.com/eth-clients/holesky) or
 [Sepolia](https://github.com/eth-clients/sepolia).
 
 If you're using [Hyperledger Besu](https://besu.hyperledger.org/en/stable/) as an execution client, you can follow the
@@ -43,7 +43,7 @@ If you're running a beacon node only, skip to the [next step](#3-start-the-execu
 If you're also running a validator client, create a test Ethereum address
 (you can do this in [MetaMask](https://metamask.zendesk.com/hc/en-us/articles/360015289452-How-to-create-an-additional-account-in-your-wallet)).
 Fund this address with testnet ETH (32 ETH and gas fees for each validator) using a faucet.
-See the list of [Goerli faucets](https://github.com/eth-clients/goerli#meta-data-g%C3%B6rli) or
+See the list of [Holesky faucets](https://github.com/eth-clients/holesky#metadata) or
 [Sepolia faucets](https://github.com/eth-clients/sepolia#meta-data-sepolia).
 
 :::note
@@ -52,7 +52,7 @@ If you're unable to get ETH using the faucet, you can ask for help on the [EthSt
 
 :::
 
-Generate validator keys for one or more validators using the [Goerli Staking Launchpad](https://goerli.launchpad.ethereum.org/).
+Generate validator keys for one or more validators using the [Holesky Staking Launchpad](https://holesky.launchpad.ethereum.org/).
 
 Remember the passwords that you use to create the validator keys, because you
 need them to [create the validator password files](#create-a-password-file-for-each-validator-key).
@@ -89,11 +89,11 @@ Open a new terminal window.
 To run Teku as a beacon node only (without validator duties), run the following command or [specify the options in a configuration file](../../how-to/configure/use-config-file.md):
 
 <Tabs>
-  <TabItem value="Goerli" label="Goerli" default>
+  <TabItem value="Holesky" label="Holesky" default>
 
 ```bash
 teku \
-    --network=goerli                             \
+    --network=holesky                             \
     --ee-endpoint=http://localhost:8551          \
     --ee-jwt-secret-file=<path to jwtsecret.hex> \
     --metrics-enabled=true                       \
@@ -130,7 +130,7 @@ You can modify the option values and add other [command line options](../../refe
 
 You can run the Teku beacon node and validator client as a [single process](#single-process) or as [separate processes](#separate-processes).
 
-You can check your validator status by searching your Ethereum address on the [Goerli Beacon Chain explorer](https://goerli.beaconcha.in/). It may take up to multiple days for your validator to be activated and start proposing blocks.
+You can check your validator status by searching your Ethereum address on the [Holesky Beacon Chain explorer](https://holesky.beaconcha.in/). It may take up to multiple days for your validator to be activated and start proposing blocks.
 
 You can also use [Prometheus and Grafana](../../how-to/monitor/use-metrics.md) to monitor your nodes.
 
@@ -140,16 +140,16 @@ To run the Teku beacon node and validator client in a single process, run the fo
 [specify the options in the configuration file](../../how-to/configure/use-config-file.md):
 
 <Tabs>
-  <TabItem value="Goerli" label="Goerli" default>
+  <TabItem value="Holesky" label="Holesky" default>
 
 ```bash
 teku \
-  --network=goerli                                          \
+  --network=holesky                                         \
   --ee-endpoint=http://localhost:8551                       \
   --ee-jwt-secret-file=<path to jwtsecret.hex>              \
   --metrics-enabled=true                                    \
   --rest-api-enabled=true                                   \
-  --checkpoint-sync-url=<checkpoint sync URL>              \
+  --checkpoint-sync-url=<checkpoint sync URL>               \
   --validators-proposer-default-fee-recipient=<ETH address> \
   --validator-keys=<path to key file>:<path to password file>[,<path to key file>:<path to password file>,...]
 ```
@@ -179,11 +179,11 @@ To run the Teku beacon node and validator client as separate processes, first [s
 On a separate machine, run Teku using the [`validator-client`](../../reference/cli/subcommands/validator-client.md) subcommand:
 
 <Tabs>
-  <TabItem value="Goerli" label="Goerli" default>
+  <TabItem value="Holesky" label="Holesky" default>
 
 ```bash
 teku validator-client \
-    --network=goerli                      \
+    --network=holesky                      \
     --beacon-node-api-endpoint=<endpoint> \
     --validator-keys=<path to key file>:<path to password file>[,<path to key file>:<path to password file>,...]
 ```
@@ -214,10 +214,10 @@ Syncing the execution client can take several days.
 ## 6. Stake ETH
 
 Stake your testnet ETH for one or more validators using the
-[Goerli Staking Launchpad](https://goerli.launchpad.ethereum.org/).
+[Holesky Staking Launchpad](https://holesky.launchpad.ethereum.org/).
 
 You can check your validator status by searching your Ethereum address on the
-[Goerli Beacon Chain explorer](https://goerli.beaconcha.in/).
+[Holesky Beacon Chain explorer](https://holesky.beaconcha.in/).
 It may take up to multiple days for your validator to be activated and start
 proposing blocks.
 

--- a/docs/get-started/install/run-docker-image.md
+++ b/docs/get-started/install/run-docker-image.md
@@ -26,7 +26,7 @@ docker run consensys/teku:latest --help
 You can specify [Teku environment variables](../../reference/cli/index.md#teku-environment-variables) with the docker image instead of the command line options.
 
 ```bash title="Example using Environment variables and CLI options"
-docker run -d -p 9000:9000/tcp -p 9000:9000/udp -p 5051:5051 -e TEKU_REST_API_ENABLED=true -e TEKU_P2P_PORT=9000 --mount type=bind,source=/Users/user1/teku/,target=/var/lib/teku consensys/teku:latest --network=goerli --eth1-endpoint=http://102.10.10.1:8545 --validator-keys=/var/lib/teku/validator/keys:/var/lib/teku/validator/passwords --data-path=/var/lib/teku --log-destination=CONSOLE
+docker run -d -p 9000:9000/tcp -p 9000:9000/udp -p 5051:5051 -e TEKU_REST_API_ENABLED=true -e TEKU_P2P_PORT=9000 --mount type=bind,source=/Users/user1/teku/,target=/var/lib/teku consensys/teku:latest --network=holesky --eth1-endpoint=http://102.10.10.1:8545 --validator-keys=/var/lib/teku/validator/keys:/var/lib/teku/validator/passwords --data-path=/var/lib/teku --log-destination=CONSOLE
 ```
 
 :::tip
@@ -44,7 +44,7 @@ If using a local volume to mount data, ensure the permissions on the directory a
 Use the Docker [`--user`](https://docs.docker.com/engine/reference/commandline/run/) option to run the container for the specified user. Use the UID because the username may not exist inside the docker container.
 
 ```bash title="Example"
-docker run -p 9000:9000/tcp -p 9000:9000/udp --user 1001:1001 --mount type=bind,source=/Users/user1/teku/,target=/var/lib/teku consensys/teku:latest --data-base-path=/var/lib/teku --network=goerli --eth1-endpoint=http://102.10.10.1:8545 --validator-keys=/var/lib/teku/validator/keys:/var/lib/teku/validator/passwords
+docker run -p 9000:9000/tcp -p 9000:9000/udp --user 1001:1001 --mount type=bind,source=/Users/user1/teku/,target=/var/lib/teku consensys/teku:latest --data-base-path=/var/lib/teku --network=holesky --eth1-endpoint=http://102.10.10.1:8545 --validator-keys=/var/lib/teku/validator/keys:/var/lib/teku/validator/passwords
 ```
 
 ## Exposing ports
@@ -63,7 +63,7 @@ docker run -p <localportP2P>:30303/tcp -p <localportP2P>:30303/udp -p <localport
 ```
 
 ```bash title="Example"
-docker run -p 30303:30303/tcp -p 30303:30303/udp -p 5051:5051 --mount type=bind,source=/Users/user1/teku/,target=/var/lib/teku consensys/teku:latest --network=goerli --data-base-path=/var/lib/teku --eth1-endpoint=http://102.10.10.1:8545 --validator-keys=/var/lib/teku/validator/keys:/var/lib/teku/validator/passwords --rest-api-enabled=true
+docker run -p 30303:30303/tcp -p 30303:30303/udp -p 5051:5051 --mount type=bind,source=/Users/user1/teku/,target=/var/lib/teku consensys/teku:latest --network=holesky --data-base-path=/var/lib/teku --eth1-endpoint=http://102.10.10.1:8545 --validator-keys=/var/lib/teku/validator/keys:/var/lib/teku/validator/passwords --rest-api-enabled=true
 ```
 
 ## Run Teku using Docker Compose
@@ -83,7 +83,7 @@ The example assumes the validators specified in [`--validator-keys`](../../refer
 Run `docker-compose up` in the directory containing the `docker-compose.yml` file to start the container.
 
 <Tabs>
-  <TabItem value="Goerli" label="Goerli" default>
+  <TabItem value="Holesky" label="Holesky" default>
 
 ```yaml
 ---
@@ -93,7 +93,7 @@ services:
     image: hyperledger/besu:latest
     command:
       [
-        "--network=goerli",
+        "--network=holesky",
         "--data-path=/var/lib/besu/data",
         "--host-allowlist=*",
         "--sync-mode=FAST",
@@ -119,7 +119,7 @@ services:
     image: consensys/teku:latest
     command:
       [
-        "--network=goerli",
+        "--network=holesky",
         "--data-base-path=/var/lib/teku/data",
         "--validators-proposer-default-fee-recipient=YOUR_WALLET",
         "--ee-endpoint=http://besu_node:8551",

--- a/docs/how-to/configure/tls.md
+++ b/docs/how-to/configure/tls.md
@@ -50,7 +50,7 @@ eth2
 Start Teku with the external signer, keystore, and truststore details:
 
 ```bash
-teku --network=goerli \
+teku --network=holesky \
 --eth1-endpoint=http://localhost:8545 \
 --validators-external-signer-public-keys=0xa99a...e44c,0xb89b...4a0b \
 --validators-external-signer-url=https://localhost:9000 \

--- a/docs/how-to/configure/use-config-file.md
+++ b/docs/how-to/configure/use-config-file.md
@@ -29,14 +29,14 @@ The [command line reference](../../reference/cli/index.md) includes configuratio
 
 ```yaml title="Sample YAML configuration file"
 # network
-network: "goerli"
+network: "holesky"
 
 # p2p
 p2p-enabled: true
 p2p-port: 9000
 
 # validators
-validator-keys: "/Users/me/node/goerli/validator/keys:/Users/me/node/goerli/validator/passwords"
+validator-keys: "/Users/me/node/holesky/validator/keys:/Users/me/node/holesky/validator/passwords"
 validators-graffiti: "Teku validator"
 
 # Eth 1

--- a/docs/how-to/use-external-signer/use-web3signer.md
+++ b/docs/how-to/use-external-signer/use-web3signer.md
@@ -18,7 +18,7 @@ Teku supports the [Web3Signer] external signing client.
 Start Teku and specify the external signer options.
 
 ```bash
-teku --network=goerli \
+teku --network=holesky \
 --eth1-endpoint=http://localhost:8545 \
 --validators-external-signer-public-keys=0xa99a...e44c,0xb89b...4a0b \
 --validators-external-signer-url=http://localhost:9000

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -543,7 +543,7 @@ Normally, at sync, Teku requests all deposit logs from the execution layer up to
 loads all deposits from the disk and replays them to recreate the merkle tree. Both operations consume peer resources
 and delay node availability on restart. The feature enabled by this option dramatically decreases the time of both
 operations by bundling deposit tree snapshots in the Teku distribution for all major
-networks (Mainnet, Gnosis, Goerli, and Sepolia) and persisting the current tree after finalization. Instead of
+networks (Mainnet, Gnosis, Holesky, and Sepolia) and persisting the current tree after finalization. Instead of
 replaying thousands of deposits on startup, Teku loads the bundled tree or a saved one.
 
 :::info Security considerations
@@ -806,9 +806,7 @@ eth1-endpoint: ["http://localhost:8545","https://mainnet.infura.io/v3/d0e21ccd0b
 
 Comma-separated list of JSON-RPC URLs of execution layer (Ethereum 1.0) nodes. Each time Teku makes a call, it finds the first provider in the list that is available, on the right chain, and in sync. This option must be specified if running a validator.
 
-If not specified (that is, you're running a beacon node only), then provide an initial state using the [`--initial-state`](#initial-state) option, or start Teku from an existing database using [`--data-path`](#data-base-path-data-path), which provides the initial state to work from. You do not need to provide an initial state if running a public network which has already started (for example, Mainnet or Goerli).
-
-If using a cloud-based service such as [Infura], then set the endpoint to the supplied URL. For example, `https://goerli.infura.io/v3/<Project_ID>`.
+If not specified (that is, you're running a beacon node only), then provide an initial state using the [`--initial-state`](#initial-state) option, or start Teku from an existing database using [`--data-path`](#data-base-path-data-path), which provides the initial state to work from. You do not need to provide an initial state if running a public network which has already started (for example, Mainnet or Holesky).
 
 :::caution
 
@@ -1647,7 +1645,6 @@ Possible values are:
 | :-------- | :-------------- | :--------- | :---------------------------------------------------------------------- |
 | `mainnet` | Consensus layer | Production | Main network                                                            |
 | `minimal` | Consensus layer | Test       | Used for local testing and development networks                         |
-| `goerli`  | Consensus layer | Test       | Multi-client testnet                                                    |
 | `gnosis`  | Consensus layer | Production | Network for the [Gnosis chain](https://www.gnosis.io/)                  |
 | `holesky` | Consensus layer | Test       | Multi-client testnet                                                    |
 | `sepolia` | Consensus layer | Test       | Multi-client testnet                                                    |

--- a/docs/reference/cli/subcommands/admin.md
+++ b/docs/reference/cli/subcommands/admin.md
@@ -314,7 +314,6 @@ Possible values are:
 | `mainnet` | Consensus layer | Production | Main network |
 | `minimal` | Consensus layer | Test | Used for local testing and development networks |
 | `holesky` | Consensus layer | Test | Multi-client testnet |
-| `goerli` | Consensus layer | Test | Multi-client testnet |
 | `gnosis` | Consensus layer | Production | Network for the [Gnosis chain](https://www.gnosis.io/) |
 | `sepolia` | Consensus layer | Test | Multi-client testnet |
 | `chiado` | Consensus layer | Test | Gnosis [testnet](https://docs.gnosischain.com/about/networks/chiado/) |
@@ -621,7 +620,6 @@ Possible values are:
 | --- | --- | --- | --- |
 | `mainnet` | Consensus layer | Production | Main network |
 | `minimal` | Consensus layer | Test | Used for local testing and development networks |
-| `goerli` | Consensus layer | Test | Multi-client testnet |
 | `gnosis` | Consensus layer | Production | Network for the [Gnosis chain](https://www.gnosis.io/) |
 | `holesky` | Consensus layer | Test | Multi-client testnet |
 | `sepolia` | Consensus layer | Test | Multi-client testnet |

--- a/docs/reference/cli/subcommands/migrate-database.md
+++ b/docs/reference/cli/subcommands/migrate-database.md
@@ -170,7 +170,6 @@ Possible values are:
 | :-- | :-- | :-- | :-- |
 | `mainnet` | Consensus layer | Production | Main network |
 | `minimal` | Consensus layer | Test | Used for local testing and development networks |
-| `goerli` | Consensus layer | Test | Multi-client testnet |
 | `gnosis` | Consensus layer | Production | Network for the [Gnosis chain](https://www.gnosis.io/) |
 | `holesky` | Consensus layer | Test | Multi-client testnet |
 | `sepolia` | Consensus layer | Test | Multi-client testnet |

--- a/docs/reference/cli/subcommands/slashing-protection.md
+++ b/docs/reference/cli/subcommands/slashing-protection.md
@@ -388,7 +388,6 @@ Possible values are:
 | --- | --- | --- | --- |
 | `mainnet` | Consensus layer | Production | Main network |
 | `minimal` | Consensus layer | Test | Used for local testing and development networks |
-| `goerli` | Consensus layer | Test | Multi-client testnet |
 | `gnosis` | Consensus layer | Production | Network for the [Gnosis chain](https://www.gnosis.io/) |
 | `holesky` | Consensus layer | Test | Multi-client testnet |
 | `sepolia` | Consensus layer | Test | Multi-client testnet |


### PR DESCRIPTION
Now that Goerli has been deprecated, we can remove any references to it from the docs.

Note: we are not changing the `versioned_docs` folders. Just the current docs version.