### PR TITLE
update theme component path

### DIFF
--- a/src/theme/DocVersionBanner/index.jsx
+++ b/src/theme/DocVersionBanner/index.jsx
@@ -9,8 +9,9 @@ import {
 } from "@docusaurus/plugin-content-docs/client";
 import { ThemeClassNames } from "@docusaurus/theme-common";
 import {
-  useDocsPreferredVersion
-} from "@docusaurus/theme-common/internal";
+  useDocsPreferredVersion,
+  useDocsVersion,
+} from '@docusaurus/plugin-content-docs/client';
 function UnreleasedVersionLabel({ siteTitle, versionMetadata }) {
   return (
     <Translate
@@ -107,7 +108,7 @@ function DocVersionBannerEnabled({ className, versionMetadata }) {
   );
 }
 export default function DocVersionBanner({ className }) {
-  const versionMetadata = useDocsPreferredVersion();
+  const versionMetadata = useDocsVersion();
   if (versionMetadata.banner) {
     return (
       <DocVersionBannerEnabled


### PR DESCRIPTION
Hi @bgravenorst @alexandratran looks like a path has been updated. I pulled the component out and changed to `docsPreferredVersion` - not sure if this PR is needed or not 

3.5.2 of docusaurus builds as is without these fixes but if we need `docsVersion` we likely need this fix in 