### PR TITLE
Removes p2p-flood-publish-enabled

### DIFF
--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -2138,46 +2138,6 @@ p2p-enabled: false
 
 Enables or disables all P2P communication. The default is `true`.
 
-### `p2p-flood-publish-enabled`
-
-<Tabs>
-  <TabItem value="Syntax" label="Syntax" default>
-
-```bash
---p2p-flood-publish-enabled[=<BOOLEAN>]
-```
-
-  </TabItem>
-  <TabItem value="Example" label="Example" >
-
-```bash
---p2p-flood-publish-enabled=false
-```
-
-  </TabItem>
-  <TabItem value="Environment variable" label="Environment variable" >
-
-```bash
-TEKU_P2P_FLOOD_PUBLISH_ENABLED=false
-```
-
-  </TabItem>
-  <TabItem value="Configuration file" label="Configuration file" >
-
-```bash
-p2p-flood-publish-enabled: false
-```
-
-  </TabItem>
-</Tabs>
-
-Enables or disables the
-[flood publishing](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#flood-publishing)
-behavior for all P2P subnets.
-When enabled, Teku uses its mesh when propagating messages from other peers, but Teku always
-publishes its own messages to all known peers in the topic.
-The default is `true`.
-
 ### `p2p-interface`, `p2p-interfaces`
 
 <Tabs>


### PR DESCRIPTION
We decided to demote the param to an experimental hidden param: https://github.com/Consensys/teku/pull/8661
So we have to remove it from the documentation.