### PR TITLE
Fix typos in `manage-keys.md`

### DIFF
--- a/docs/how-to/use-external-signer/manage-keys.md
+++ b/docs/how-to/use-external-signer/manage-keys.md
@@ -106,7 +106,7 @@ Multiple addresses can be specified when using openSSL to generate the certifica
     IP.2 = 10.0.0.6
     ```
 
-    You should adjust the `req_distinguised_name` and `alt_names` sections to
+    You should adjust the `req_distinguished_name` and `alt_names` sections to
     match your needs.
 
 2. Create a plain text file (for example, `validator_keystore_pass.txt`) that

--- a/versioned_docs/version-24.10.0/how-to/use-external-signer/manage-keys.md
+++ b/versioned_docs/version-24.10.0/how-to/use-external-signer/manage-keys.md
@@ -106,7 +106,7 @@ Multiple addresses can be specified when using openSSL to generate the certifica
     IP.2 = 10.0.0.6
     ```
 
-    You should adjust the `req_distinguised_name` and `alt_names` sections to
+    You should adjust the `req_distinguished_name` and `alt_names` sections to
     match your needs.
 
 2. Create a plain text file (for example, `validator_keystore_pass.txt`) that

--- a/versioned_docs/version-24.10.1/how-to/use-external-signer/manage-keys.md
+++ b/versioned_docs/version-24.10.1/how-to/use-external-signer/manage-keys.md
@@ -106,7 +106,7 @@ Multiple addresses can be specified when using openSSL to generate the certifica
     IP.2 = 10.0.0.6
     ```
 
-    You should adjust the `req_distinguised_name` and `alt_names` sections to
+    You should adjust the `req_distinguished_name` and `alt_names` sections to
     match your needs.
 
 2. Create a plain text file (for example, `validator_keystore_pass.txt`) that

--- a/versioned_docs/version-24.10.2/how-to/use-external-signer/manage-keys.md
+++ b/versioned_docs/version-24.10.2/how-to/use-external-signer/manage-keys.md
@@ -106,7 +106,7 @@ Multiple addresses can be specified when using openSSL to generate the certifica
     IP.2 = 10.0.0.6
     ```
 
-    You should adjust the `req_distinguised_name` and `alt_names` sections to
+    You should adjust the `req_distinguished_name` and `alt_names` sections to
     match your needs.
 
 2. Create a plain text file (for example, `validator_keystore_pass.txt`) that

--- a/versioned_docs/version-24.10.3/how-to/use-external-signer/manage-keys.md
+++ b/versioned_docs/version-24.10.3/how-to/use-external-signer/manage-keys.md
@@ -106,7 +106,7 @@ Multiple addresses can be specified when using openSSL to generate the certifica
     IP.2 = 10.0.0.6
     ```
 
-    You should adjust the `req_distinguised_name` and `alt_names` sections to
+    You should adjust the `req_distinguished_name` and `alt_names` sections to
     match your needs.
 
 2. Create a plain text file (for example, `validator_keystore_pass.txt`) that

--- a/versioned_docs/version-24.12.0/how-to/use-external-signer/manage-keys.md
+++ b/versioned_docs/version-24.12.0/how-to/use-external-signer/manage-keys.md
@@ -106,7 +106,7 @@ Multiple addresses can be specified when using openSSL to generate the certifica
     IP.2 = 10.0.0.6
     ```
 
-    You should adjust the `req_distinguised_name` and `alt_names` sections to
+    You should adjust the `req_distinguished_name` and `alt_names` sections to
     match your needs.
 
 2. Create a plain text file (for example, `validator_keystore_pass.txt`) that

--- a/versioned_docs/version-24.12.1/how-to/use-external-signer/manage-keys.md
+++ b/versioned_docs/version-24.12.1/how-to/use-external-signer/manage-keys.md
@@ -106,7 +106,7 @@ Multiple addresses can be specified when using openSSL to generate the certifica
     IP.2 = 10.0.0.6
     ```
 
-    You should adjust the `req_distinguised_name` and `alt_names` sections to
+    You should adjust the `req_distinguished_name` and `alt_names` sections to
     match your needs.
 
 2. Create a plain text file (for example, `validator_keystore_pass.txt`) that

--- a/versioned_docs/version-24.6.0/how-to/use-external-signer/manage-keys.md
+++ b/versioned_docs/version-24.6.0/how-to/use-external-signer/manage-keys.md
@@ -106,7 +106,7 @@ Multiple addresses can be specified when using openSSL to generate the certifica
     IP.2 = 10.0.0.6
     ```
 
-    You should adjust the `req_distinguised_name` and `alt_names` sections to
+    You should adjust the `req_distinguished_name` and `alt_names` sections to
     match your needs.
 
 2. Create a plain text file (for example, `validator_keystore_pass.txt`) that

--- a/versioned_docs/version-24.6.1/how-to/use-external-signer/manage-keys.md
+++ b/versioned_docs/version-24.6.1/how-to/use-external-signer/manage-keys.md
@@ -106,7 +106,7 @@ Multiple addresses can be specified when using openSSL to generate the certifica
     IP.2 = 10.0.0.6
     ```
 
-    You should adjust the `req_distinguised_name` and `alt_names` sections to
+    You should adjust the `req_distinguished_name` and `alt_names` sections to
     match your needs.
 
 2. Create a plain text file (for example, `validator_keystore_pass.txt`) that

--- a/versioned_docs/version-24.8.0/how-to/use-external-signer/manage-keys.md
+++ b/versioned_docs/version-24.8.0/how-to/use-external-signer/manage-keys.md
@@ -106,7 +106,7 @@ Multiple addresses can be specified when using openSSL to generate the certifica
     IP.2 = 10.0.0.6
     ```
 
-    You should adjust the `req_distinguised_name` and `alt_names` sections to
+    You should adjust the `req_distinguished_name` and `alt_names` sections to
     match your needs.
 
 2. Create a plain text file (for example, `validator_keystore_pass.txt`) that

--- a/versioned_docs/version-25.1.0/how-to/use-external-signer/manage-keys.md
+++ b/versioned_docs/version-25.1.0/how-to/use-external-signer/manage-keys.md
@@ -106,7 +106,7 @@ Multiple addresses can be specified when using openSSL to generate the certifica
     IP.2 = 10.0.0.6
     ```
 
-    You should adjust the `req_distinguised_name` and `alt_names` sections to
+    You should adjust the `req_distinguished_name` and `alt_names` sections to
     match your needs.
 
 2. Create a plain text file (for example, `validator_keystore_pass.txt`) that


### PR DESCRIPTION
- Fixed typos in `manage-keys.md` in multiple versioned documentation files.