### PR TITLE
Fix typos and improve consistency in slashing-protection documentation

### DIFF
--- a/docs/reference/cli/subcommands/slashing-protection.md
+++ b/docs/reference/cli/subcommands/slashing-protection.md
@@ -12,7 +12,7 @@ Manage the local [slashing protection data] used by the validator.
 
 ## `export`
 
-Exports the slashing protection database in the [validator client interchange format] format.
+Exports the slashing protection database in the [validator client interchange format].
 
 ### `config-file`
 
@@ -395,7 +395,7 @@ Possible values are:
 | `chiado`   | Consensus layer | Test       | Gnosis [testnet](https://docs.gnosischain.com/about/networks/chiado/) |
 | `lukso`    | Consensus layer | Production | Network for the [Lukso chain](https://lukso.network/)                 |
 
-Predefined networks can provide defaults such the initial state of the network, bootnodes, and the address of the deposit contract.
+Predefined networks can provide defaults such as the initial state of the network, bootnodes, and the address of the deposit contract.
 
 ### `slot`
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -19,7 +19,7 @@ const config = {
   // If you aren't using GitHub pages, you don't need these.
   organizationName: "ConsenSys", // Usually your GitHub org/user name.
   projectName: "doc.teku", // Usually your repo name.
-  deploymentBranch: "gh-pages", // Github Pages deploying branch
+  deploymentBranch: "gh-pages", // GitHub Pages deployment branch
 
   // Even if you don't use internalization, you can use this field to set useful
   // metadata like html lang. For example, if your site is Chinese, you may want
@@ -85,7 +85,7 @@ const config = {
       //   content: "⛔️ This documentation site is still under construction! 🚧",
       //   backgroundColor: "#fafbfc",
       //   textColor: "#091E42",
-      //   isCloseable: false,
+      //   isClosable: false,
       // },
       colorMode: {
         defaultMode: "light",

--- a/versioned_docs/version-24.8.0/reference/cli/subcommands/slashing-protection.md
+++ b/versioned_docs/version-24.8.0/reference/cli/subcommands/slashing-protection.md
@@ -12,7 +12,7 @@ Manage the local [slashing protection data] used by the validator.
 
 ## `export`
 
-Exports the slashing protection database in the [validator client interchange format] format.
+Exports the slashing protection database in the [validator client interchange format].
 
 ### `config-file`
 
@@ -394,7 +394,7 @@ Possible values are:
 | `chiado` | Consensus layer | Test | Gnosis [testnet](https://docs.gnosischain.com/about/networks/chiado/) |
 | `lukso` | Consensus layer | Production | Network for the [Lukso chain](https://lukso.network/) |
 
-Predefined networks can provide defaults such the initial state of the network, bootnodes, and the address of the deposit contract.
+Predefined networks can provide defaults such as the initial state of the network, bootnodes, and the address of the deposit contract.
 
 ### `slot`
 


### PR DESCRIPTION
- Fixed a redundant word: Removed an extra "format" in "Exports the slashing protection database in the [validator client interchange format] format."

- Grammar improvement: Changed "Predefined networks can provide defaults such the initial state" to "Predefined networks can provide defaults such as the initial state."

- Config cleanup: Standardized wording in `docusaurus.config.js` by fixing "Github Pages deploying branch" to "GitHub Pages deployment branch."