### PR TITLE
added clarification to the voluntary-exits howto

### DIFF
--- a/docs/how-to/voluntarily-exit.md
+++ b/docs/how-to/voluntarily-exit.md
@@ -56,8 +56,9 @@ Use the [`/eth/v1/beacon/pool/voluntary_exits`](https://consensys.github.io/teku
 
 ## Create but don't submit an exit
 
-Use the [`voluntary-exit`](../reference/cli/subcommands/voluntary-exit.md) subcommand to create a
-signed exit for the specified validators, but not submit it to the beacon node.
+The [`voluntary-exit`](../reference/cli/subcommands/voluntary-exit.md) subcommand accepts an option [`--save-exits-path`](../reference/cli/subcommands/voluntary-exit.md#save-exits-path), which creates a signed exit without submitting it to the beacon node.
+
+This [`--save-exits-path`](../reference/cli/subcommands/voluntary-exit.md#save-exits-path) parameter allows an operator to create the voluntary exits for validators, and save them for future use. These exit messages (from deneb fork) will be valid for the current or any future hard fork - they do not become invalid at any point in time.
 
 ```bash title="Example"
 teku voluntary-exit                                \
@@ -79,6 +80,9 @@ In this example, a JSON file is written to the current folder (`.`) containing a
 for validator `1e9f2a`.
 At a future time when this exit needs to be processed, you can use the beacon API to submit
 this message using a POST request to `/eth/v1/beacon/voluntary_exits`.
+
+The `--beacon-node-api-endpoint` is still required even though the voluntary-exit is not being submitted, as it verifys the status of the validator, and needs network parameters to generate a valid message.
+
 
 <!-- links -->
 


### PR DESCRIPTION
I'm not sure this is quite perfect, but the key issue is that it wasn't clear to users that this part of the howto was to just generate and not publish exits to the beacon node, so i've attempted to clarify what the point of the example is.

Also added a clarification on why we need the beacon-node endpoint if we're not submitting an exit so that theres some more context.

Not sure if some of this should be in notes or something, but hopefully another set of eyes can help :)