### PR TITLE
Fixed default gas limit

### DIFF
--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -3417,7 +3417,7 @@ validators-builder-registration-default-gas-limit: 40000000
 </Tabs>
 
 The gas limit used for [registering validators to the builder endpoint](../../how-to/configure/builder-network.md#3-register-the-validator).
-The default is `36000000`.
+The default is `60000000`.
 
 ### `validators-early-attestations-enabled`
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the documented default for `validators-builder-registration-default-gas-limit` from `36000000` to `60000000` in `docs/reference/cli/index.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f51dcfed8192481d0b698c0127938e7864168bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->