### PR TITLE
Update teku memory recommendation

### DIFF
--- a/docs/get-started/manage-memory.md
+++ b/docs/get-started/manage-memory.md
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 Manage Teku's Java Virtual Machine (JVM) memory usage by setting a maximum heap size using the `JAVA_OPTS` environment variable.
 
-We recommend setting the maximum heap size to 5GB or more.
+We recommend setting the maximum heap size to 8GB or more.
 
 Set the heap size using the environment variable, or using the command line when starting Teku.
 
@@ -19,14 +19,14 @@ Set the heap size using the environment variable, or using the command line when
   <TabItem value="Environment variable" label="Environment variable" default>
 
 ```bash
-export JAVA_OPTS=-Xmx5g
+export JAVA_OPTS=-Xmx8g
 ```
 
   </TabItem>
   <TabItem value="Command line" label="Command line" >
 
 ```bash
-JAVA_OPTS=-Xmx5g ./teku [options]
+JAVA_OPTS=-Xmx8g ./teku [options]
 ```
 
   </TabItem>

--- a/docs/how-to/troubleshoot/network.md
+++ b/docs/how-to/troubleshoot/network.md
@@ -94,8 +94,8 @@ Common issues include:
   Monitor CPU stats, and watch the terminal for frequent `regenerating state` messages, common during Teku's struggle.
   In this context, enabling [`--p2p-subscribe-all-subnets`](../../reference/cli/index.md#p2p-subscribe-all-subnets-enabled) can worsen the situation by raising CPU usage.
   A typical problem arises when JVM lacks adequate heap allocation, causing aggressive garbage collection.
-  Ensure an environment variable like `JAVA_OPTS=-Xmx5g` is set, with `5g` (five gigabytes of heap) as an optimal value;
-  `4g` is acceptable, while anything much lower may lead to problems.
+  Ensure an environment variable like `JAVA_OPTS=-Xmx8g` is set, with `8g` (five gigabytes of heap) as an optimal value;
+  `7g` is acceptable, while anything much lower may lead to problems.
 
 - **Time sync on your server is poor**.
   Ensure `ntpd` or `chrony` is configured correctly.


### PR DESCRIPTION
Updated from 5gb tro 8gb recommended.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Raise Teku JVM heap recommendation to 8GB across docs and update examples/troubleshooting accordingly.
> 
> - **Docs**:
>   - **Memory guidance**: Increase recommended JVM heap to `8GB` in `docs/get-started/manage-memory.md`; update example commands to use `JAVA_OPTS=-Xmx8g`.
>   - **Troubleshooting**: In `docs/how-to/troubleshoot/network.md`, revise heap guidance to suggest `JAVA_OPTS=-Xmx8g` and adjust acceptable lower bound to `7g`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9fd3d449a5c3ab1794e0c99dff5e2cd6b95f231. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->