### PR TITLE
added block production metrics cli

### DIFF
--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -1391,6 +1391,41 @@ The logging verbosity.
 Log levels are `OFF`, `FATAL`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`, and `ALL`.
 The default is `INFO`.
 
+### `metrics-block-production-performance-tracking-enabled`
+
+<Tabs>
+  <TabItem value="Syntax" label="Syntax" default>
+
+```bash
+--metrics-block-production-performance-tracking-enabled[=<BOOLEAN>]
+```
+
+  </TabItem>
+  <TabItem value="Example" label="Example" >
+
+```bash
+--metrics-block-production-performance-tracking-enabled=false
+```
+
+  </TabItem>
+  <TabItem value="Environment variable" label="Environment variable" >
+
+```bash
+TEKU_METRICS_BLOCK_PRODUCTION_PERFORMANCE_TRACKING_ENABLED=false
+```
+
+  </TabItem>
+  <TabItem value="Configuration file" label="Configuration file" >
+
+```bash
+metrics-block-production-performance-tracking-enabled: false
+```
+
+  </TabItem>
+</Tabs>
+
+Enables or disables block production performance metrics. The default is `false`.
+
 ### `metrics-block-timing-tracking-enabled`
 
 <Tabs>


### PR DESCRIPTION
added `--metrics-block-production-performance-tracking-enabled` which defaults to false.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documents new CLI flag `--metrics-block-production-performance-tracking-enabled` to toggle block production performance metrics (default false).
> 
> - **Docs** (`docs/reference/cli/index.md`):
>   - Add new CLI option `metrics-block-production-performance-tracking-enabled`:
>     - Syntax: `--metrics-block-production-performance-tracking-enabled[=<BOOLEAN>]`
>     - Env var: `TEKU_METRICS_BLOCK_PRODUCTION_PERFORMANCE_TRACKING_ENABLED`
>     - Config file key: `metrics-block-production-performance-tracking-enabled`
>     - Default: `false` (enables/disables block production performance metrics)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd21247c45adf0f238c5a3a8133e01fc10d9a3d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->