### PR TITLE
Add new get-blobs-api CLI params

### DIFF
--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -2952,7 +2952,7 @@ or for requests outside the local retention period (if peers still hold the data
 
 :::note
 
-Retrieved sidecars are treated as standard custody data and are subject to the network pruning retention limits (`MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS`).
+Retrieved sidecars are treated as standard custody data and are subject to the network pruning [retention limits](https://github.com/ethereum/consensus-specs/blob/master/specs/fulu/validator.md#sidecar-retention).
 
 :::
 


### PR DESCRIPTION
related to https://github.com/Consensys/teku/pull/10234 and https://github.com/Consensys/teku/pull/10251


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates CLI reference to cover new getBlobs sidecar retrieval options.
> 
> - Adds `--rest-api-getblobs-sidecars-download-enabled` to allow serving `getBlobs` by fetching missing blob sidecars via P2P and persisting them locally (subject to standard retention)
> - Adds `--rest-api-getblobs-sidecars-download-timeout` to set the max wait (default `5s`) for sidecar retrieval; only applies when the above flag is enabled
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f3a9f3bce54ef22fd2489b1afda09ff41baf0fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->