### PR TITLE
Update ignorePatterns to support website

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -18,6 +18,7 @@ ignorePatterns:
 - pattern: '^http(s)?://.+.etherscan.io'
 - pattern: '^http(s)?://help.figma.com'
 - pattern: '^http(s)?://metamask.io'
+- pattern: '^http(s)?://(www\.)?freedesktop\.org'
 aliveStatusCodes:
 - 200
 - 206


### PR DESCRIPTION
Add freedesktop.org to linkspector ignore patterns to fix CI failures. The freedesktop.org server returns HTTP 418 to block automated link checkers, causing false positive errors for valid systemd documentation links.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an ignore rule to prevent CI from flagging valid freedesktop.org links.
> 
> - Update `.linkspector.yml` `ignorePatterns` to include `^http(s)?://(www\.)?freedesktop\.org`
> - Mitigates CI failures where freedesktop.org blocks automated checkers (HTTP 418)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8128f68089c258e8ee6e89f538bf3e91ff6166d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->