### PR TITLE
feat: add LLM crawling support via robots.txt and docusaurus-plugin-llms

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -257,6 +257,28 @@ const config = {
       },
     ],
     [
+      "docusaurus-plugin-llms",
+      {
+        docsDir: "docs",
+        generateLLMsTxt: true,
+        generateLLMsFullTxt: true,
+        title: "Teku documentation",
+        description:
+          "Official Teku documentation: Ethereum consensus client, installation, configuration, staking, and operations.",
+        excludeImports: true,
+        removeDuplicateHeadings: true,
+        logLevel: process.env.CI ? "quiet" : "normal",
+        ignoreFiles: ["images/**"],
+        includeOrder: [
+          "get-started/**/*",
+          "concepts/**/*",
+          "how-to/**/*",
+          "tutorials/**/*",
+          "reference/**/*",
+        ],
+      },
+    ],
+    [
       "@docusaurus/plugin-client-redirects",
       {
         redirects: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@easyops-cn/docusaurus-search-local": "^0.55.0",
         "@mdx-js/react": "^3.1.1",
         "clsx": "^2.1.1",
+        "docusaurus-plugin-llms": "^0.4.0",
         "open-ask-ai": "^0.7.3",
         "prism-react-renderer": "^2.4.1",
         "react": "^19.0.0",
@@ -8480,7 +8481,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -10674,6 +10674,27 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/docusaurus-plugin-llms": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-llms/-/docusaurus-plugin-llms-0.4.0.tgz",
+      "integrity": "sha512-jYlj2HJ5+gu7oJZuJ83Hk8KlB65YlZZ/7UpHXiL7Qr+qpNBkVocmt2Molc6F3HNr5RqcfhWD/98CvgyNztg/ow==",
+      "license": "MIT",
+      "dependencies": {
+        "gray-matter": "^4.0.3",
+        "minimatch": "^9.0.3",
+        "yaml": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rachfop"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0"
       }
     },
     "node_modules/dom-converter": {
@@ -17144,7 +17165,6 @@
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
       "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -30211,6 +30231,21 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -34,10 +34,11 @@
     "@easyops-cn/docusaurus-search-local": "^0.55.0",
     "@mdx-js/react": "^3.1.1",
     "clsx": "^2.1.1",
+    "docusaurus-plugin-llms": "^0.4.0",
+    "open-ask-ai": "^0.7.3",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "open-ask-ai": "^0.7.3"
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.4",

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,19 @@
+# https://www.rfc-editor.org/rfc/rfc9309
+# Teku documentation — allow indexing and AI crawlers.
+
+User-agent: *
+Allow: /
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+Sitemap: https://docs.teku.consensys.io/sitemap.xml


### PR DESCRIPTION
## Summary

- Add `static/robots.txt` explicitly allowing GPTBot, OAI-SearchBot, PerplexityBot, and Google-Extended AI crawlers
- Install and configure `docusaurus-plugin-llms@^0.4.0` to generate `/llms.txt` and `/llms-full.txt` at build time for AI crawler discoverability


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-site-only changes (static robots rules and a Docusaurus build plugin); no application runtime, auth, or data-handling impact.
> 
> **Overview**
> Adds **AI-oriented discoverability** for the Teku docs site: a new `static/robots.txt` allows general indexing and explicitly permits several AI crawlers (`GPTBot`, `OAI-SearchBot`, `PerplexityBot`, `Google-Extended`), and points crawlers at the production sitemap.
> 
> The build is extended with **`docusaurus-plugin-llms`** (`^0.4.0`), configured in `docusaurus.config.js` to emit **`/llms.txt`** and **`/llms-full.txt`** from the `docs` tree (ordered sections, images ignored, quieter logs in CI). Dependency lockfile updates follow the new package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8cdad72965b5d3165be588044f1ea1ac0e35509. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->