### PR TITLE
DOC-761: Drop Windows support for Teku

### DIFF
--- a/docs/get-started/install/build-from-source.md
+++ b/docs/get-started/install/build-from-source.md
@@ -6,6 +6,13 @@ sidebar_position: 2
 
 # Build from source
 
+:::caution Windows is not supported
+
+Teku does not support Windows. Windows users may switch to using Docker, Windows Subsystem for
+Linux, or other supported operating systems.
+
+:::
+
 :::caution
 
 If you want to use the latest development version of Teku or a specific commit, build from source. Otherwise, use the [binary] or [Docker image] for more stable versions.

--- a/docs/get-started/install/build-from-source.md
+++ b/docs/get-started/install/build-from-source.md
@@ -13,26 +13,23 @@ Linux, or other supported operating systems.
 
 :::
 
-:::caution
-
-If you want to use the latest development version of Teku or a specific commit, build from source. Otherwise, use the [binary] or [Docker image] for more stable versions.
-
-:::
+If you want to use the latest development version of Teku or a specific commit, build from source.
+Otherwise, use the [binary] or [Docker image] for more stable versions.
 
 ## Prerequisites
 
 - [Java JDK](https://www.oracle.com/java/technologies/javase-downloads.html)
 
-:::caution
+  :::caution
 
-Teku requires Java 25+; earlier versions are not supported.
+  Teku requires Java 25+; earlier versions are not supported.
 
-:::
+  :::
 
 - [Git](https://git-scm.com/downloads) or [GitHub Desktop](https://desktop.github.com/)
 - [Gradle build tool](https://gradle.org/)
 
-## Installation on Linux / Unix / MacOS X
+## Installation on Linux / Unix / macOS
 
 ### Clone the Teku repository
 

--- a/docs/get-started/install/build-from-source.md
+++ b/docs/get-started/install/build-from-source.md
@@ -6,13 +6,6 @@ sidebar_position: 2
 
 # Build from source
 
-:::caution Windows is not supported
-
-Teku does not support Windows. Windows users may switch to using Docker, Windows Subsystem for
-Linux, or other supported operating systems.
-
-:::
-
 If you want to use the latest development version of Teku or a specific commit, build from source.
 Otherwise, use the [binary] or [Docker image] for more stable versions.
 

--- a/docs/get-started/install/install-binaries.md
+++ b/docs/get-started/install/install-binaries.md
@@ -8,7 +8,8 @@ sidebar_position: 1
 
 :::caution Windows is not supported
 
-Teku no longer supports Windows.
+Teku does not support Windows. Windows users may switch to using Docker, Windows Subsystem for
+Linux, or other supported operating systems.
 
 :::
 

--- a/docs/get-started/install/install-binaries.md
+++ b/docs/get-started/install/install-binaries.md
@@ -4,12 +4,15 @@ description: Install Teku from binary distribution.
 sidebar_position: 1
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # Install binary distribution
 
-## Linux / Unix / macOS / Windows
+:::caution Windows is not supported
+
+Teku no longer supports Windows.
+
+:::
+
+## Linux / Unix / macOS
 
 ### Prerequisites
 
@@ -21,10 +24,6 @@ Teku requires Java 25+ to run; earlier versions are not supported.
 
 :::
 
-<!-- markdown-link-check-disable-next-line -->
-
-- If using Windows, install the [Microsoft Visual C++ 2010 security update](https://www.microsoft.com/en-us/download/details.aspx?id=26999).
-
 ### Install from packaged binaries
 
 Download the [Teku packaged binaries](https://github.com/ConsenSys/teku/releases).
@@ -33,22 +32,9 @@ Unpack the downloaded files and change into the `teku-<release>` directory.
 
 Display Teku command line help to confirm installation:
 
-<Tabs>
-  <TabItem value="Linux/macOS" label="Linux/macOS" default>
-
 ```bash
 ./bin/teku --help
 ```
-
-  </TabItem>
-  <TabItem value="Windows" label="Windows" >
-
-```bat
-bin\teku --help
-```
-
-  </TabItem>
-</Tabs>
 
 ## macOS with Homebrew
 

--- a/docs/get-started/install/install-binaries.md
+++ b/docs/get-started/install/install-binaries.md
@@ -6,13 +6,6 @@ sidebar_position: 1
 
 # Install binary distribution
 
-:::caution Windows is not supported
-
-Teku does not support Windows. Windows users may switch to using Docker, Windows Subsystem for
-Linux, or other supported operating systems.
-
-:::
-
 ## Linux / Unix / macOS
 
 ### Prerequisites

--- a/docs/get-started/system-requirements.md
+++ b/docs/get-started/system-requirements.md
@@ -16,7 +16,8 @@ The following are the minimum system requirements for running a full node, with 
 
 :::caution Windows is not supported
 
-Teku no longer supports Windows.
+Teku does not support Windows. Windows users may switch to using Docker, Windows Subsystem for
+Linux, or other supported operating systems.
 
 :::
 

--- a/docs/get-started/system-requirements.md
+++ b/docs/get-started/system-requirements.md
@@ -11,8 +11,14 @@ The following are the minimum system requirements for running a full node, with 
 - CPU: 4 cores at 2.8 GHz
 - Memory: 16 GB RAM
 - Storage: SSD with 2 TB free space
-- Operating system: 64-bit Linux, Mac OS X, or Windows
+- Operating system: 64-bit Linux or Mac OS X
 - Internet: Broadband internet connection (10 Mbps)
+
+:::caution Windows is not supported
+
+Teku no longer supports Windows.
+
+:::
 
 :::note
 We also recommend that you have an uninterrupted power supply (UPS) to ensure your node is always available.

--- a/docs/get-started/system-requirements.md
+++ b/docs/get-started/system-requirements.md
@@ -11,7 +11,7 @@ The following are the minimum system requirements for running a full node, with 
 - CPU: 4 cores at 2.8 GHz
 - Memory: 16 GB RAM
 - Storage: SSD with 2 TB free space
-- Operating system: 64-bit Linux or Mac OS X
+- Operating system: 64-bit Linux or macOS
 - Internet: Broadband internet connection (10 Mbps)
 
 :::caution Windows is not supported

--- a/docs/how-to/monitor/configure-logging.md
+++ b/docs/how-to/monitor/configure-logging.md
@@ -16,7 +16,6 @@ The default log directory is OS dependent:
 
 - macOS: `~/Library/teku/logs`
 - Unix/Linux: `$XDG_DATA_HOME/teku/logs` if `$XDG_DATA_HOME` is set; otherwise `~/.local/share/teku/logs`
-- Windows: `%localappdata%\teku\logs`
 
 The default Docker image location is `/root/.local/share/teku/logs`.
 

--- a/docs/how-to/monitor/use-metrics.md
+++ b/docs/how-to/monitor/use-metrics.md
@@ -10,7 +10,7 @@ Enable the [Prometheus](https://prometheus.io/) monitoring and alerting service 
 
 ## Install Prometheus
 
-To use Prometheus with Teku, install the [Prometheus main component](https://prometheus.io/download/). On MacOS, install with [Homebrew](https://formulae.brew.sh/formula/prometheus):
+To use Prometheus with Teku, install the [Prometheus main component](https://prometheus.io/download/). On macOS, install with [Homebrew](https://formulae.brew.sh/formula/prometheus):
 
 ```bash
 brew install prometheus

--- a/docs/how-to/monitor/use-metrics.md
+++ b/docs/how-to/monitor/use-metrics.md
@@ -20,7 +20,7 @@ brew install prometheus
 
 To configure Prometheus and run with Teku:
 
-1.  Configure Prometheus to poll Teku. For example, add the following YAML fragment to the `scrape_configs` block of the `prometheus.yml` file:
+1. Configure Prometheus to poll Teku. For example, add the following YAML fragment to the `scrape_configs` block of the `prometheus.yml` file:
 
     ```yaml title="Example configuration"
     global:
@@ -37,7 +37,7 @@ To configure Prometheus and run with Teku:
           - targets: ["localhost:8008"]
     ```
 
-2.  Start Teku with the [`--metrics-enabled`](../../reference/cli/index.md#metrics-enabled) option. To start a node for testing with metrics enabled:
+2. Start Teku with the [`--metrics-enabled`](../../reference/cli/index.md#metrics-enabled) option. To start a node for testing with metrics enabled:
 
     ```bash
     teku --eth1-deposit-contract-address=dddddddddddddddddddddddddddddddddddddddd \
@@ -48,21 +48,26 @@ To configure Prometheus and run with Teku:
 
     :::warning
 
-    To avoid DNS rebinding attacks, if running Prometheus on a different host to your Teku node (any host other than `localhost`), ensure you add the hostname that Prometheus uses to connect to Teku to [`--metrics-host-allowlist`](../../reference/cli/index.md#metrics-host-allowlist).
+    To avoid DNS rebinding attacks, if running Prometheus on a different host to your Teku node
+    (any host other than `localhost`), ensure you add the hostname that Prometheus uses to connect
+    to Teku to [`--metrics-host-allowlist`](../../reference/cli/index.md#metrics-host-allowlist).
 
     For example, if Prometheus is configured to get metrics from `http://teku.local:8008/metrics` then `teku.local` has to be in `--metrics-host-allowlist`.
 
     :::
 
-    To specify the host and port on which Prometheus accesses Teku, use the [`--metrics-interface`](../../reference/cli/index.md#metrics-interface) and [`--metrics-port`](../../reference/cli/index.md#metrics-port) options. The default host and port are 127.0.0.1 and 8008.
+    To specify the host and port on which Prometheus accesses Teku, use the
+    [`--metrics-interface`](../../reference/cli/index.md#metrics-interface) and
+    [`--metrics-port`](../../reference/cli/index.md#metrics-port) options.
+    The default host and port are 127.0.0.1 and 8008.
 
-3.  In another terminal, run Prometheus specifying the `prometheus.yml` file:
+3. In another terminal, run Prometheus specifying the `prometheus.yml` file:
 
     ```bash
     prometheus --config.file=prometheus.yml
     ```
 
-4.  View the [Prometheus graphical interface](#view-prometheus-graphical-interface).
+4. View the [Prometheus graphical interface](#view-prometheus-graphical-interface).
 
 :::tip
 
@@ -72,11 +77,11 @@ Use a log ingestion tool, such as Logstash, to parse the logs and alert you to c
 
 ## View Prometheus graphical interface
 
-1.  Open a web browser to `http://localhost:9090` to view the Prometheus graphical interface.
+1. Open a web browser to `http://localhost:9090` to view the Prometheus graphical interface.
 
-2.  Choose **Graph** from the menu bar and click the **Console** tab below.
+2. Choose **Graph** from the menu bar and click the **Console** tab below.
 
-3.  From the **Insert metric at cursor** drop-down, select a metric such as `libp2p_peers` or `beacon_finalized_epoch` and click **Execute**. The values display.
+3. From the **Insert metric at cursor** drop-down, select a metric such as `libp2p_peers` or `beacon_finalized_epoch` and click **Execute**. The values display.
 
     :::note
 

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -320,7 +320,6 @@ The path to the Teku data directory. The default directory is OS-dependent:
 
 - macOS: `~/Library/teku`
 - Unix/Linux: `$XDG_DATA_HOME/teku` if `$XDG_DATA_HOME` is set; otherwise `~/.local/share/teku`
-- Windows: `%localappdata%\teku`.
 
 The default Docker image location is `/root/.local/share/teku`.
 
@@ -1281,7 +1280,6 @@ The default directory is OS-dependent:
 
 - macOS: `~/Library/teku/logs`
 - Unix/Linux: `$XDG_DATA_HOME/teku/logs` if `$XDG_DATA_HOME` is set; otherwise `~/.local/share/teku/logs`
-- Windows: `%localappdata%\teku\logs`
 
 The default Docker image location is `/root/.local/share/teku/logs`.
 
@@ -4290,12 +4288,6 @@ the keystore files.
 :::
 
 When specifying file names, Teku expects that the files exist.
-
-:::note
-
-The path separator is operating system dependent, and should be `;` in Windows rather than `:`.
-
-:::
 
 ### `validators-keystore-locking-enabled`
 

--- a/docs/reference/cli/subcommands/admin.md
+++ b/docs/reference/cli/subcommands/admin.md
@@ -83,7 +83,6 @@ Path to the Teku data directory. The default directory is OS-dependent:
 
 - macOS: `~/Library/teku`
 - Unix/Linux: `$XDG_DATA_HOME/teku` if `$XDG_DATA_HOME` is set; otherwise `~/.local/share/teku`
-- Windows: `%localappdata%\teku`.
 
 The default Docker image location is `/root/.local/share/teku`.
 
@@ -395,7 +394,6 @@ Path to the Teku data directory. The default directory is OS-dependent:
 
 - macOS: `~/Library/teku`
 - Unix/Linux: `$XDG_DATA_HOME/teku` if `$XDG_DATA_HOME` is set; otherwise `~/.local/share/teku`
-- Windows: `%localappdata%\teku`.
 
 The default Docker image location is `/root/.local/share/teku`.
 

--- a/docs/reference/cli/subcommands/bootnode.md
+++ b/docs/reference/cli/subcommands/bootnode.md
@@ -236,7 +236,6 @@ Path to the Teku base directory for storage. The default directory is OS-depende
 
 - macOS: `~/Library/teku`
 - Unix/Linux: `$XDG_DATA_HOME/teku` if `$XDG_DATA_HOME` is set; otherwise `~/.local/share/teku`
-- Windows: `%localappdata%\teku`.
 
 The default Docker image location is `/root/.local/share/teku`.
 

--- a/docs/reference/cli/subcommands/migrate-database.md
+++ b/docs/reference/cli/subcommands/migrate-database.md
@@ -88,7 +88,6 @@ Path to the Teku data directory. The default directory is OS-dependent:
 
 - macOS: `~/Library/teku`
 - Unix/Linux: `$XDG_DATA_HOME/teku` if `$XDG_DATA_HOME` is set; otherwise `~/.local/share/teku`
-- Windows: `%localappdata%\teku`
 
 The default Docker image location is `/root/.local/share/teku`.
 

--- a/docs/reference/cli/subcommands/slashing-protection.md
+++ b/docs/reference/cli/subcommands/slashing-protection.md
@@ -65,7 +65,6 @@ Path to the Teku data directory. The default directory is OS-dependent:
 
 - macOS: `~/Library/teku`
 - Unix/Linux: `$XDG_DATA_HOME/teku` if `$XDG_DATA_HOME` is set; otherwise `~/.local/share/teku`
-- Windows: `%localappdata%\teku`.
 
 ### `data-validator-path`
 
@@ -192,7 +191,6 @@ Path to the Teku data directory. The default directory is OS-dependent:
 
 - macOS: `~/Library/teku`
 - Unix/Linux: `$XDG_DATA_HOME/teku` if `$XDG_DATA_HOME` is set; otherwise `~/.local/share/teku`
-- Windows: `%localappdata%\teku`.
 
 ### `data-validator-path`
 
@@ -329,7 +327,6 @@ Path to the Teku data directory. The default directory is OS-dependent:
 
 - macOS: `~/Library/teku`
 - Unix/Linux: `$XDG_DATA_HOME/teku` if `$XDG_DATA_HOME` is set; otherwise `~/.local/share/teku`
-- Windows: `%localappdata%\teku`
 
 The default Docker image location is `/root/.local/share/teku`.
 

--- a/docs/reference/cli/subcommands/validator-client.md
+++ b/docs/reference/cli/subcommands/validator-client.md
@@ -155,7 +155,6 @@ Path to the Teku base directory for storage. The default directory is OS-depende
 
 - macOS: `~/Library/teku`
 - Unix/Linux: `$XDG_DATA_HOME/teku` if `$XDG_DATA_HOME` is set; otherwise `~/.local/share/teku`
-- Windows: `%localappdata%\teku`.
 
 The default Docker image location is `/root/.local/share/teku`.
 
@@ -322,7 +321,6 @@ The default directory is OS-dependent:
 
 - macOS: `~/Library/teku/logs`
 - Unix/Linux: `$XDG_DATA_HOME/teku/logs` if `$XDG_DATA_HOME` is set; otherwise `~/.local/share/teku/logs`
-- Windows: `%localappdata%\teku\logs`
 
 The default Docker image location is `/root/.local/share/teku/logs`.
 
@@ -706,12 +704,6 @@ When specifying directories, Teku expects to find identically named keystore and
 example `validator_217179e.json` and `validator_217179e.txt`.
 
 When specifying file names, Teku expects that the files exist.
-
-:::note
-
-The path separator is operating system dependent, and should be `;` in Windows rather than `:`.
-
-:::
 
 ## `validators-early-attestations-enabled`
 

--- a/docs/reference/cli/subcommands/voluntary-exit.md
+++ b/docs/reference/cli/subcommands/voluntary-exit.md
@@ -294,12 +294,6 @@ When specifying directories, Teku expects to find identically named keystore and
 
 When specifying file names, Teku expects that the files exist.
 
-:::note
-
-The path separator is operating system dependent, and should be `;` in Windows rather than `:`.
-
-:::
-
 ## `validator-public-keys`
 
 <Tabs>

--- a/docs/reference/cli/subcommands/voluntary-exit.md
+++ b/docs/reference/cli/subcommands/voluntary-exit.md
@@ -288,7 +288,8 @@ validator-keys: "/home/validator/keys:home/validator/passwords"
   </TabItem>
 </Tabs>
 
-Directory or file to load the encrypted keystores and passwords of the validators that you wish to exit. Keystore files must use the `.json` file extension, and password files must use the `.txt` file extension.
+Directory or file to load the encrypted keystores and passwords of the validators that you wish to exit.
+Keystore files must use the `.json` file extension, and password files must use the `.txt` file extension.
 
 When specifying directories, Teku expects to find identically named keystore and password files. For example `validator_217179e.json` and `validator_217179e.txt`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5850,6 +5850,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5865,6 +5868,9 @@
       "integrity": "sha512-pJh+SzrK1HaKakhdFM+ew9vXwpZqMxy9u0U7J4GT+3GvOwnAZ+KjeaHebIfgOz7ZHvp/T4YBNf8oWW4zwj3AJw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5882,6 +5888,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5897,6 +5906,9 @@
       "integrity": "sha512-h45HMVU/hgzQ0saXNsK9fKlGdah1i1cXZULpB5vQRlRL2ZIaGp+ULtWTogS7vkoo2K8s2l4tqakWMg9eUjIJ2A==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5850,9 +5850,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5868,9 +5865,6 @@
       "integrity": "sha512-pJh+SzrK1HaKakhdFM+ew9vXwpZqMxy9u0U7J4GT+3GvOwnAZ+KjeaHebIfgOz7ZHvp/T4YBNf8oWW4zwj3AJw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5888,9 +5882,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5906,9 +5897,6 @@
       "integrity": "sha512-h45HMVU/hgzQ0saXNsK9fKlGdah1i1cXZULpB5vQRlRL2ZIaGp+ULtWTogS7vkoo2K8s2l4tqakWMg9eUjIJ2A==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## Summary

Teku no longer builds, tests, or distributes Windows binaries (see Consensys/teku#10850). This PR removes Windows-specific content from the current docs and adds callouts noting that Windows is no longer supported.

Versioned docs (`26.2.0`, `26.3.0`, `26.4.0`) are intentionally left unchanged as historical snapshots of releases where Windows was supported.

## Changes

- **System requirements**: drop Windows from the supported OS list and add a caution callout.
- **Install binaries**: update the heading, remove the Microsoft Visual C++ prerequisite, remove the Windows install tab (collapsed to a single code block), drop the now-unused `Tabs`/`TabItem` imports, and add a caution callout.
- **CLI reference** (`index.md` plus `admin`, `bootnode`, `migrate-database`, `slashing-protection`, `validator-client`, `voluntary-exit`): remove the Windows `%localappdata%\teku` data-path and log-path entries and the "path separator should be `;` in Windows" notes.
- **Logging how-to**: remove the Windows log-path entry.
- Fixed references to old "MacOS X" to official "macOS" 

## Fixes

Closes Consensys/doc.teku#761

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API impact; risk is limited to readers missing the Windows callout if they only read versioned historical docs.
> 
> **Overview**
> Updates current Teku docs to match dropped Windows builds, tests, and binaries (DOC-761).
> 
> **System requirements** now list only 64-bit Linux and macOS, with a caution that Windows is unsupported and alternatives (Docker, WSL, other OSes) are suggested.
> 
> **Install guides** no longer cover Windows: binary install drops the Visual C++ prerequisite, Docusaurus `Tabs` for Windows vs Linux/macOS, and the section title is Linux/Unix/macOS only; build-from-source uses plain text instead of a top-level caution admonition and renames the platform heading to macOS.
> 
> **CLI reference** (`index.md` and admin, bootnode, migrate-database, slashing-protection, validator-client, voluntary-exit) removes Windows default paths (`%localappdata%\teku`) for data and logs and deletes notes that validator path separators use `;` on Windows.
> 
> **Logging how-to** drops the Windows default log directory. Minor copy fixes use **macOS** instead of MacOS/Mac OS X; **use-metrics** has light formatting only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 304ff561ab4771bb5cb5d9e4c598e81ad13b17b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->