### PR TITLE
[codex] Update network troubleshooting peer checks

### DIFF
--- a/docs/how-to/find-and-connect/configure-ipv6.md
+++ b/docs/how-to/find-and-connect/configure-ipv6.md
@@ -12,7 +12,8 @@ You can configure Teku to listen over IPv4, [IPv6](#listen-over-only-ipv6), or
 
 To configure Teku to listen only on IPv6, set the
 [`--p2p-interface`](../../reference/cli/index.md#p2p-interface-p2p-interfaces) CLI option to `::`.
-The [`--p2p-port`](../../reference/cli/index.md#p2p-port) and
+The [`--p2p-port`](../../reference/cli/index.md#p2p-port), 
+[`--p2p-quic-port`](../../reference/cli/index.md#p2p-quic-port), and
 [`--p2p-udp-port`](../../reference/cli/index.md#p2p-udp-port) CLI options are used for the P2P and
 discovery ports, similar to listening over IPv4 only.
 
@@ -21,13 +22,15 @@ discovery ports, similar to listening over IPv4 only.
 To configure Teku to listen over both IPv4 and IPv6, also known as dual-stack support, set the
 [`--p2p-interface`](../../reference/cli/index.md#p2p-interface-p2p-interfaces) CLI option to
 `0.0.0.0,::` for both IPv4 and IPv6 listening addresses. 
-In this setup, the [`--p2p-port`](../../reference/cli/index.md#p2p-port) and
+In this setup, the [`--p2p-port`](../../reference/cli/index.md#p2p-port), 
+[`--p2p-quic-port`](../../reference/cli/index.md#p2p-quic-port), and
 [`--p2p-udp-port`](../../reference/cli/index.md#p2p-udp-port) options apply to the IPv4 address.
-The [`--p2p-port-ipv6`](../../reference/cli/index.md#p2p-port-ipv6) and
+The [`--p2p-port-ipv6`](../../reference/cli/index.md#p2p-port-ipv6),
+[`--p2p-quic-port-ipv6`](../../reference/cli/index.md#p2p-quic-port-ipv6) and
 [`--p2p-udp-port-ipv6`](../../reference/cli/index.md#p2p-udp-port-ipv6) options apply to the IPv6 address.
 
-After dual-stack support is enabled, Teku uses port `9000` for both TCP and UDP on IPv4, and port
-`9090` for both TCP and UDP on IPv6 by default.
+After dual-stack support is enabled, Teku uses port `9000` for both TCP and UDP on IPv4, 9001 for UDP for QUIC, and port
+`9090` for both TCP and UDP and `9091` for UDP on QUIC, on IPv6 by default.
 
 ## Advertise only the IPv6 address
 
@@ -35,9 +38,11 @@ To advertise only the IPv6 public address to the network, use the
 [`--p2p-advertised-ip`](../../reference/cli/index.md#p2p-advertised-ip-p2p-advertised-ips) CLI option. 
 This is similar to advertising an IPv4 address.
 Configure the advertised port using the
-[`--p2p-advertised-port`](../../reference/cli/index.md#p2p-advertised-port) CLI option. 
-It uses the value set in [`--p2p-port`](../../reference/cli/index.md#p2p-port) by default.
-
+[`--p2p-advertised-port-ipv6`](../../reference/cli/index.md#p2p-advertised-port-ipv6) CLI option. 
+It uses the value set in [`--p2p-port-ipv6`](../../reference/cli/index.md#p2p-port-ipv6) by default.
+Configure the advertised quic port using the 
+[`--p2p-advertised-quic-port-ipv6`](../../reference/cli/index.md#p2p-advertised-quic-port-ipv6) CLI option.
+It uses the [`--p2p-quic-port-ipv6`](../../reference/cli/index.md#p2p-quic-port) by default.
 ## Advertise both IPv4 and IPv6 addresses (dual-stack)
 
 To advertise both the IPv4 and IPv6 public addresses to the network, use the

--- a/docs/how-to/find-and-connect/configure-ipv6.md
+++ b/docs/how-to/find-and-connect/configure-ipv6.md
@@ -12,7 +12,7 @@ You can configure Teku to listen over IPv4, [IPv6](#listen-over-only-ipv6), or
 
 To configure Teku to listen only on IPv6, set the
 [`--p2p-interface`](../../reference/cli/index.md#p2p-interface-p2p-interfaces) CLI option to `::`.
-The [`--p2p-port`](../../reference/cli/index.md#p2p-port), 
+The [`--p2p-port`](../../reference/cli/index.md#p2p-port),
 [`--p2p-quic-port`](../../reference/cli/index.md#p2p-quic-port), and
 [`--p2p-udp-port`](../../reference/cli/index.md#p2p-udp-port) CLI options are used for the P2P and
 discovery ports, similar to listening over IPv4 only.
@@ -21,8 +21,8 @@ discovery ports, similar to listening over IPv4 only.
 
 To configure Teku to listen over both IPv4 and IPv6, also known as dual-stack support, set the
 [`--p2p-interface`](../../reference/cli/index.md#p2p-interface-p2p-interfaces) CLI option to
-`0.0.0.0,::` for both IPv4 and IPv6 listening addresses. 
-In this setup, the [`--p2p-port`](../../reference/cli/index.md#p2p-port), 
+`0.0.0.0,::` for both IPv4 and IPv6 listening addresses.
+In this setup, the [`--p2p-port`](../../reference/cli/index.md#p2p-port),
 [`--p2p-quic-port`](../../reference/cli/index.md#p2p-quic-port), and
 [`--p2p-udp-port`](../../reference/cli/index.md#p2p-udp-port) options apply to the IPv4 address.
 The [`--p2p-port-ipv6`](../../reference/cli/index.md#p2p-port-ipv6),
@@ -35,21 +35,22 @@ After dual-stack support is enabled, Teku uses port `9000` for both TCP and UDP 
 ## Advertise only the IPv6 address
 
 To advertise only the IPv6 public address to the network, use the
-[`--p2p-advertised-ip`](../../reference/cli/index.md#p2p-advertised-ip-p2p-advertised-ips) CLI option. 
+[`--p2p-advertised-ip`](../../reference/cli/index.md#p2p-advertised-ip-p2p-advertised-ips) CLI option.
 This is similar to advertising an IPv4 address.
 Configure the advertised port using the
-[`--p2p-advertised-port-ipv6`](../../reference/cli/index.md#p2p-advertised-port-ipv6) CLI option. 
+[`--p2p-advertised-port-ipv6`](../../reference/cli/index.md#p2p-advertised-port-ipv6) CLI option.
 It uses the value set in [`--p2p-port-ipv6`](../../reference/cli/index.md#p2p-port-ipv6) by default.
-Configure the advertised quic port using the 
+Configure the advertised QUIC port using the
 [`--p2p-advertised-quic-port-ipv6`](../../reference/cli/index.md#p2p-advertised-quic-port-ipv6) CLI option.
 It uses the [`--p2p-quic-port-ipv6`](../../reference/cli/index.md#p2p-quic-port) by default.
+
 ## Advertise both IPv4 and IPv6 addresses (dual-stack)
 
 To advertise both the IPv4 and IPv6 public addresses to the network, use the
 [`--p2p-advertised-ips`](../../reference/cli/index.md#p2p-advertised-ip-p2p-advertised-ips) CLI
-option and provide the two addresses, separated by a comma. 
+option and provide the two addresses, separated by a comma.
 Configure the advertised port for the IPv4 address using the
-[`--p2p-advertised-port`](../../reference/cli/index.md#p2p-advertised-port) option. 
+[`--p2p-advertised-port`](../../reference/cli/index.md#p2p-advertised-port) option.
 Configure the advertised port for the IPv6 address using the
-[`--p2p-advertised-port-ipv6`](../../reference/cli/index.md#p2p-advertised-port-ipv6) option. 
+[`--p2p-advertised-port-ipv6`](../../reference/cli/index.md#p2p-advertised-port-ipv6) option.
 This port is set to the value of [`--p2p-port-ipv6`](../../reference/cli/index.md#p2p-port-ipv6) by default.

--- a/docs/how-to/troubleshoot/network.md
+++ b/docs/how-to/troubleshoot/network.md
@@ -52,7 +52,7 @@ performance.
 ### Firewall connection issues
 
 To determine the number of inbound and outbound peers via the beacon node's
-REST API, send a request to the peers endpoint.
+REST API, send a request to the peer's endpoint.
 This command groups peers by direction and counts peer addresses that include
 `/tcp/` or `/quic`.
 
@@ -79,11 +79,11 @@ Interpret the output by transport:
 - If the output shows outbound TCP peers, but no inbound TCP peers, inbound TCP
   traffic might be blocked.
   Allow and forward `TCP` traffic on the
-  [`--p2p-port`](../../reference/cli/index.md#p2p-port), (9000 by default).
+  [`--p2p-port`](../../reference/cli/index.md#p2p-port), (`9000`` by default).
 - If the output shows outbound QUIC peers, but no inbound QUIC peers, inbound
   QUIC traffic might be blocked.
   Allow and forward `UDP` traffic on the port configured with
-  `--p2p-quic-port`, (9001 by default).
+  `--p2p-quic-port`, (`9001` by default).
 
 Networks typically have a firewall at the entry point (router, modem, or
 gateway) that blocks incoming data by default.
@@ -115,12 +115,12 @@ A potential reason for incoming peers not being able to connect could be the use
 gateway (router or modem).
 This usually happens because only one service can listen on a port. Therefore, if you're running multiple beacon nodes,
 you'll need to open multiple ports on your gateway. The simplest solution is to use the same port on your gateway as
-specified in your [`--p2p-port`](../../reference/cli/index.md#p2p-port) (9000 by default). However, if necessary, users
+specified in your [`--p2p-port`](../../reference/cli/index.md#p2p-port) (`9000` by default). However, if necessary, users
 can also update the advertised port using the [`--p2p-advertised-port`](../../reference/cli/index.md#p2p-advertised-port)
 command.
 
-Similarly for [`--p2p-quic-port`](../../reference/cli/index.md#p2p-quic-port) (9001 by default),
-an advertised port can be set for quic using the 
+Similarly for [`--p2p-quic-port`](../../reference/cli/index.md#p2p-quic-port) (`9001` by default),
+an advertised port can be set for QUIC using the 
 [`--p2p-advertised-quic-port`](../../reference/cli/index.md#p2p-advertised-quic-port) command.
 
 ## Resolve poor attestation performance

--- a/docs/how-to/troubleshoot/network.md
+++ b/docs/how-to/troubleshoot/network.md
@@ -51,25 +51,54 @@ performance.
 
 ### Firewall connection issues
 
-To determine the number of inbound and outbound peers via the beacon node's REST API, you can send a request to the peers
-endpoint. This gathers data and organizes it based on the direction, either inbound or outbound.
+To determine the number of inbound and outbound peers via the beacon node's
+REST API, send a request to the peers endpoint.
+This command groups peers by direction and counts peer addresses that include
+`/tcp/` or `/quic`.
 
 ```bash
-curl http://127.0.0.1:5051/eth/v1/node/peers |jq '.data | group_by(.direction)[] | {direction: .[0].direction, count: length}'
+curl -s http://127.0.0.1:5051/eth/v1/node/peers | jq '
+  .data
+  | group_by(.direction)[]
+  | {
+      direction: .[0].direction,
+      tcp: (
+        map(select((.last_seen_p2p_address // "") | contains("/tcp/")))
+        | length
+      ),
+      quic: (
+        map(select((.last_seen_p2p_address // "") | contains("/quic")))
+        | length
+      )
+    }
+'
 ```
 
-If only outbound peers are displayed, it indicates that peers cannot connect to your infrastructure from the outside.
-Networks typically have a firewall at the entry point (router / modem / gateway) that blocks incoming data by default.
+Interpret the output by transport:
 
-To resolve this, update the firewall to include a rule that allows access to the [`--p2p-port`](../../reference/cli/index.md#p2p-port) (9000 by default)
-for both `UDP` and `TCP` traffic. Subsequently, forward this port (TCP and UDP) to the internal IP address of the machine
-running the beacon node. Some operating systems also have local firewalls that should be updated to permit communication
-through this port.
+- If the output shows outbound TCP peers, but no inbound TCP peers, inbound TCP
+  traffic might be blocked.
+  Allow and forward `TCP` traffic on the
+  [`--p2p-port`](../../reference/cli/index.md#p2p-port), which defaults to
+  `9000`.
+- If the output shows outbound QUIC peers, but no inbound QUIC peers, inbound
+  QUIC traffic might be blocked.
+  Allow and forward `UDP` traffic on the port configured with
+  `--Xp2p-quic-port`, which defaults to `9001`.
+
+Networks typically have a firewall at the entry point (router, modem, or
+gateway) that blocks incoming data by default.
+Forward the required TCP and QUIC ports to the internal IP address of the
+machine running the beacon node.
+Some operating systems also have local firewalls that should be updated to
+permit communication through these ports.
 
 :::info
 
-View the [Prysm guide](https://docs.prylabs.network/docs/prysm-usage/p2p-host-ip/) for more information on this topic,
-but you need to substitute  your `--p2p-port` (9000 by default) for the port numbers.
+View the [Prysm guide](https://docs.prylabs.network/docs/prysm-usage/p2p-host-ip/)
+for more information on this topic, but use your Teku ports for the firewall
+rules: `--p2p-port` for TCP traffic and `--Xp2p-quic-port` for QUIC over UDP
+traffic.
 
 :::
 

--- a/docs/how-to/troubleshoot/network.md
+++ b/docs/how-to/troubleshoot/network.md
@@ -120,7 +120,7 @@ can also update the advertised port using the [`--p2p-advertised-port`](../../re
 command.
 
 Similarly for [`--p2p-quic-port`](../../reference/cli/index.md#p2p-quic-port) (`9001` by default),
-an advertised port can be set for QUIC using the 
+an advertised port can be set for QUIC using the
 [`--p2p-advertised-quic-port`](../../reference/cli/index.md#p2p-advertised-quic-port) command.
 
 ## Resolve poor attestation performance

--- a/docs/how-to/troubleshoot/network.md
+++ b/docs/how-to/troubleshoot/network.md
@@ -79,12 +79,11 @@ Interpret the output by transport:
 - If the output shows outbound TCP peers, but no inbound TCP peers, inbound TCP
   traffic might be blocked.
   Allow and forward `TCP` traffic on the
-  [`--p2p-port`](../../reference/cli/index.md#p2p-port), which defaults to
-  `9000`.
+  [`--p2p-port`](../../reference/cli/index.md#p2p-port), (9000 by default).
 - If the output shows outbound QUIC peers, but no inbound QUIC peers, inbound
   QUIC traffic might be blocked.
   Allow and forward `UDP` traffic on the port configured with
-  `--Xp2p-quic-port`, which defaults to `9001`.
+  `--p2p-quic-port`, (9001 by default).
 
 Networks typically have a firewall at the entry point (router, modem, or
 gateway) that blocks incoming data by default.
@@ -97,7 +96,7 @@ permit communication through these ports.
 
 View the [Prysm guide](https://docs.prylabs.network/docs/prysm-usage/p2p-host-ip/)
 for more information on this topic, but use your Teku ports for the firewall
-rules: `--p2p-port` for TCP traffic and `--Xp2p-quic-port` for QUIC over UDP
+rules: `--p2p-port` for TCP traffic and `--p2p-quic-port` for QUIC over UDP
 traffic.
 
 :::
@@ -119,6 +118,10 @@ you'll need to open multiple ports on your gateway. The simplest solution is to 
 specified in your [`--p2p-port`](../../reference/cli/index.md#p2p-port) (9000 by default). However, if necessary, users
 can also update the advertised port using the [`--p2p-advertised-port`](../../reference/cli/index.md#p2p-advertised-port)
 command.
+
+Similarly for [`--p2p-quic-port`](../../reference/cli/index.md#p2p-quic-port) (9001 by default),
+an advertised port can be set for quic using the 
+[`--p2p-advertised-quic-port`](../../reference/cli/index.md#p2p-advertised-quic-port) command.
 
 ## Resolve poor attestation performance
 

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -2015,7 +2015,7 @@ p2p-advertised-quic-port-ipv6: 1790
 
 The P2P [IPv6](../../how-to/find-and-connect/configure-ipv6.md) QUIC port to advertise.
 Use this port only when advertising both IPv4 and IPv6 addresses.
-The default is the port specified in [`--p2p-quic-port-ipv6`](#p2p-port-quic-ipv6).
+The default is the port specified in [`--p2p-quic-port-ipv6`](#p2p-quic-port-ipv6).
 
 ### `p2p-advertised-udp-port`
 

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -1972,11 +1972,11 @@ p2p-advertised-quic-port: 1789
   </TabItem>
 </Tabs>
 
-The P2P Quic port to advertise.
-The default is the port specified in [`--p2p-quic-port`](#p2-quic-port).
+The P2P QUIC port to advertise.
+The default is the port specified in [`--p2p-quic-port`](#p2p-quic-port).
 
 The advertised port can differ from the [`--p2p-quic-port`](#p2p-quic-port).
-For example, you can set the advertised quic port to `9010`, and the `--p2p-quic-port` value to `9009`, then
+For example, you can set the advertised QUIC port to `9010`, and the `--p2p-quic-port` value to `9009`, then
 manually configure the firewall to forward external incoming requests on port `9010` to port `9009`
 on the Teku node.
 
@@ -2013,7 +2013,7 @@ p2p-advertised-quic-port-ipv6: 1790
   </TabItem>
 </Tabs>
 
-The P2P [IPv6](../../how-to/find-and-connect/configure-ipv6.md) quic port to advertise.
+The P2P [IPv6](../../how-to/find-and-connect/configure-ipv6.md) QUIC port to advertise.
 Use this port only when advertising both IPv4 and IPv6 addresses.
 The default is the port specified in [`--p2p-quic-port-ipv6`](#p2p-port-quic-ipv6).
 

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -1939,6 +1939,84 @@ The P2P [IPv6](../../how-to/find-and-connect/configure-ipv6.md) port to advertis
 Use this port only when advertising both IPv4 and IPv6 addresses.
 The default is the port specified in [`--p2p-port-ipv6`](#p2p-port-ipv6).
 
+### `p2p-advertised-quic-port`
+
+<Tabs>
+  <TabItem value="Syntax" label="Syntax" default>
+
+```bash
+--p2p-advertised-quic-port=<PORT>
+```
+
+  </TabItem>
+  <TabItem value="Example" label="Example" >
+
+```bash
+--p2p-advertised-quic-port=1789
+```
+
+  </TabItem>
+  <TabItem value="Environment variable" label="Environment variable" >
+
+```bash
+TEKU_P2P_ADVERTISED_QUIC_PORT=1789
+```
+
+  </TabItem>
+  <TabItem value="Configuration file" label="Configuration file" >
+
+```bash
+p2p-advertised-quic-port: 1789
+```
+
+  </TabItem>
+</Tabs>
+
+The P2P Quic port to advertise.
+The default is the port specified in [`--p2p-quic-port`](#p2-quic-port).
+
+The advertised port can differ from the [`--p2p-quic-port`](#p2p-quic-port).
+For example, you can set the advertised quic port to `9010`, and the `--p2p-quic-port` value to `9009`, then
+manually configure the firewall to forward external incoming requests on port `9010` to port `9009`
+on the Teku node.
+
+### `p2p-advertised-quic-port-ipv6`
+
+<Tabs>
+  <TabItem value="Syntax" label="Syntax" default>
+
+```bash
+--p2p-advertised-quic-port-ipv6=<PORT>
+```
+
+  </TabItem>
+  <TabItem value="Example" label="Example" >
+
+```bash
+--p2p-advertised-quic-port-ipv6=1790
+```
+
+  </TabItem>
+  <TabItem value="Environment variable" label="Environment variable" >
+
+```bash
+TEKU_P2P_ADVERTISED_QUIC_PORT_IPV6=1790
+```
+
+  </TabItem>
+  <TabItem value="Configuration file" label="Configuration file" >
+
+```bash
+p2p-advertised-quic-port-ipv6: 1790
+```
+
+  </TabItem>
+</Tabs>
+
+The P2P [IPv6](../../how-to/find-and-connect/configure-ipv6.md) quic port to advertise.
+Use this port only when advertising both IPv4 and IPv6 addresses.
+The default is the port specified in [`--p2p-quic-port-ipv6`](#p2p-port-quic-ipv6).
+
 ### `p2p-advertised-udp-port`
 
 <Tabs>
@@ -2482,6 +2560,82 @@ p2p-port-ipv6: 1790
 The P2P listening ports (UDP and TCP) for [IPv6](../../how-to/find-and-connect/configure-ipv6.md)
 when listening over both IPv4 and IPv6.
 The default is `9090`.
+
+### `p2p-quic-port`
+
+<Tabs>
+  <TabItem value="Syntax" label="Syntax" default>
+
+```bash
+--p2p-quic-port=<PORT>
+```
+
+  </TabItem>
+  <TabItem value="Example" label="Example" >
+
+```bash
+# to listen on port 1789
+--p2p-quic-port=1789
+```
+
+  </TabItem>
+  <TabItem value="Environment variable" label="Environment variable" >
+
+```bash
+# to listen on port 1789
+TEKU_P2P_QUIC_PORT=1789
+```
+
+  </TabItem>
+  <TabItem value="Configuration file" label="Configuration file" >
+
+```bash
+p2p-quic-port: 1789
+```
+
+  </TabItem>
+</Tabs>
+
+The P2P QUIC listening port (UDP). The default is `9001`.
+
+### `p2p-quic-port-ipv6`
+
+<Tabs>
+  <TabItem value="Syntax" label="Syntax" default>
+
+```bash
+--p2p-quic-port-ipv6=<PORT>
+```
+
+  </TabItem>
+  <TabItem value="Example" label="Example" >
+
+```bash
+# to listen on port 1790
+--p2p-quic-port-ipv6=1790
+```
+
+  </TabItem>
+  <TabItem value="Environment variable" label="Environment variable" >
+
+```bash
+# to listen on port 1790
+TEKU_P2P_QUIC_PORT_IPV6=1790
+```
+
+  </TabItem>
+  <TabItem value="Configuration file" label="Configuration file" >
+
+```bash
+p2p-quic-port-ipv6: 1790
+```
+
+  </TabItem>
+</Tabs>
+
+The P2P QUIC listening port (UDP) for [IPv6](../../how-to/find-and-connect/configure-ipv6.md)
+when listening over both IPv4 and IPv6.
+The default is `9091`.
 
 ### `p2p-private-key-file`
 


### PR DESCRIPTION
## What changed

- Updated the network troubleshooting guide peer query to report TCP and QUIC counts for inbound and outbound peers.
- Reworked the firewall guidance to separate TCP and QUIC troubleshooting paths.
- Clarified that TCP uses `--p2p-port` by default and QUIC over UDP uses `--Xp2p-quic-port`, which defaults to `9001`.

## Why

The previous guidance used a single inbound/outbound peer count and described firewall fixes without clearly separating TCP from QUIC. This made it harder to diagnose cases where outbound QUIC peers exist but inbound QUIC peers are missing.

## Validation

- `git diff --check`
- `npm run build`

The build completed successfully and reported existing broken-anchor warnings unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to documentation; no runtime or configuration behavior is modified.
> 
> **Overview**
> **Documentation-only** updates so operators can tell **TCP** and **QUIC** P2P apart when debugging connectivity.
> 
> The **network troubleshooting** guide replaces a single inbound/outbound peer count with a **`jq`** query that reports **TCP** and **QUIC** counts per direction, and rewrites **firewall** guidance so missing inbound TCP vs QUIC peers map to **`--p2p-port`** (TCP) vs **`--p2p-quic-port`** (UDP, default **9001**). **Gateway** notes now mention **`--p2p-advertised-quic-port`**.
> 
> **IPv6** and **CLI reference** pages add **`--p2p-quic-port`**, **`--p2p-quic-port-ipv6`**, and advertised QUIC port options, including dual-stack default ports (**9001** / **9091**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3bad8bc1c361326b2689d5e476e26417ca2235b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->