### PR TITLE
improve agent readiness

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -19,6 +19,10 @@ ignorePatterns:
 - pattern: '^http(s)?://help.figma.com'
 - pattern: '^http(s)?://metamask.io'
 - pattern: '^http(s)?://(www\.)?freedesktop\.org'
+# Root-absolute static asset paths (served from static/ by Docusaurus). These
+# are resolved and validated at build time, but the link checker resolves them
+# against the repo root rather than the static/ web root.
+- pattern: '^/img/'
 aliveStatusCodes:
 - 200
 - 206

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,22 @@ The canonical Teku REST API documentation is hosted at
 Use `docs/reference/rest.md` as local guidance and linking context, not as the primary source for
 complete endpoint definitions.
 
+## Agent readiness
+
+The site is configured so AI agents and LLM tools can discover, read, and cite it:
+
+| Feature | Where | Notes |
+|---------|-------|-------|
+| `llms.txt` / `llms-full.txt` | `docusaurus-plugin-llms` in `docusaurus.config.js` | Generated at build time. |
+| Raw Markdown at `.md` URLs | `scripts/copy-md-to-build.js` (chained in `npm run build`) | Exports the stable (root) version only; appending `.md` to a root doc URL returns its Markdown source. |
+| Copy page button | `docusaurus-plugin-copy-page-button` via swizzled `src/theme/DocItem/Layout` | Copy as Markdown / open in an AI assistant. |
+| Content negotiation | `vercel.json` `headers` and `rewrites` | Advertises `llms.txt`/`sitemap.xml` and serves Markdown for `Accept: text/markdown`. |
+| Crawler permissions | `static/robots.txt` | Content signals and AI crawler allow rules. |
+| Agent landing page | `static/index.md` | Served at the root for `Accept: text/markdown`. |
+
+When moving, renaming, or deleting stable pages, remember the raw `.md` pipeline mirrors the
+stable version served at the root.
+
 ## AI guidance
 
 Detailed editorial, formatting, and product-specific rules are in `.cursor/rules/`.

--- a/docs/get-started/start-teku.md
+++ b/docs/get-started/start-teku.md
@@ -76,8 +76,8 @@ You can specify [`--rest-api-host-allowlist`](../reference/cli/index.md#rest-api
 
 To run a validator, connect to a [running beacon node].
 
-Use the [`validator-client`](../reference/cli/subcommands/validator-client.md#validator-client-vc) or
-[`vc`](../reference/cli/subcommands/validator-client.md#validator-client-vc) subcommand to run a Teku as a validator.
+Use the [`validator-client`](../reference/cli/subcommands/validator-client.md) or
+[`vc`](../reference/cli/subcommands/validator-client.md) subcommand to run a Teku as a validator.
 
 ```title="Example"
 teku validator-client \

--- a/docs/how-to/prevent-slashing/detect-doppelgangers.md
+++ b/docs/how-to/prevent-slashing/detect-doppelgangers.md
@@ -13,7 +13,7 @@ When enabled, doppelganger detection is triggered from two entry points:
     doppelganger is detected, the Teku validator client shuts down after it finishes the check with
     exit code `2`.
     When this happens, you should not restart Teku by default because validators will likely be slashed.
-2. When importing keys via the [key manager API](https://ethereum.github.io/keymanager-APIs/): Any detected 
+2. When importing keys via the [key manager API](https://ethereum.github.io/keymanager-APIs/): Any detected
     doppelganger's keys are ignored (not imported).
     The other keys are imported and the validators start performing their duties after it finishes the check.
 

--- a/docs/how-to/prevent-slashing/detect-doppelgangers.md
+++ b/docs/how-to/prevent-slashing/detect-doppelgangers.md
@@ -13,7 +13,9 @@ When enabled, doppelganger detection is triggered from two entry points:
     doppelganger is detected, the Teku validator client shuts down after it finishes the check with
     exit code `2`.
     When this happens, you should not restart Teku by default because validators will likely be slashed.
-2. When importing keys via the [key manager API](https://ethereum.github.io/keymanager-APIs/): Any detected doppelganger's keys are ignored (not imported). The other keys are imported and the validators start performing their duties after it finishes the check.
+2. When importing keys via the [key manager API](https://ethereum.github.io/keymanager-APIs/): Any detected 
+    doppelganger's keys are ignored (not imported).
+    The other keys are imported and the validators start performing their duties after it finishes the check.
 
 :::warning
 

--- a/docs/how-to/prevent-slashing/detect-doppelgangers.md
+++ b/docs/how-to/prevent-slashing/detect-doppelgangers.md
@@ -9,7 +9,7 @@ Doppelganger detection checks if the validators' keys are already active before 
 
 When enabled, doppelganger detection is triggered from two entry points:
 
-1. At [validator client startup](../../get-started/start-teku.md#start-teku): If at least one
+1. At [validator client startup](../../get-started/start-teku.md): If at least one
     doppelganger is detected, the Teku validator client shuts down after it finishes the check with
     exit code `2`.
     When this happens, you should not restart Teku by default because validators will likely be slashed.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -53,7 +53,7 @@ const config = {
             "**/__tests__/**",
           ],
           showLastUpdateAuthor: false,
-          showLastUpdateTime: true,
+          showLastUpdateTime: false,
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@easyops-cn/docusaurus-search-local": "^0.55.0",
         "@mdx-js/react": "^3.1.1",
         "clsx": "^2.1.1",
+        "docusaurus-plugin-copy-page-button": "^0.5.0",
         "docusaurus-plugin-llms": "^0.4.0",
         "open-ask-ai": "^0.7.3",
         "prism-react-renderer": "^2.4.1",
@@ -5850,9 +5851,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5868,9 +5866,6 @@
       "integrity": "sha512-pJh+SzrK1HaKakhdFM+ew9vXwpZqMxy9u0U7J4GT+3GvOwnAZ+KjeaHebIfgOz7ZHvp/T4YBNf8oWW4zwj3AJw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5888,9 +5883,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5906,9 +5898,6 @@
       "integrity": "sha512-h45HMVU/hgzQ0saXNsK9fKlGdah1i1cXZULpB5vQRlRL2ZIaGp+ULtWTogS7vkoo2K8s2l4tqakWMg9eUjIJ2A==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -11460,6 +11449,19 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/docusaurus-plugin-copy-page-button": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-copy-page-button/-/docusaurus-plugin-copy-page-button-0.5.2.tgz",
+      "integrity": "sha512-k1zdpHWPSktyxTnKfi5kN4ObDDYXQ7HEJBBL5euSTuQfE+SKryvGeDyt8uDhS0FFNcWjTbYPU+AxNWSgqe2Zfg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0",
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/docusaurus-plugin-llms": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "docusaurus build",
+    "build": "docusaurus build && node scripts/copy-md-to-build.js",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
@@ -32,6 +32,7 @@
     "@docusaurus/plugin-google-tag-manager": "^3.10.1",
     "@docusaurus/preset-classic": "^3.10.1",
     "@easyops-cn/docusaurus-search-local": "^0.55.0",
+    "docusaurus-plugin-copy-page-button": "^0.5.0",
     "docusaurus-plugin-llms": "^0.4.0",
     "@mdx-js/react": "^3.1.1",
     "clsx": "^2.1.1",

--- a/scripts/copy-md-to-build.js
+++ b/scripts/copy-md-to-build.js
@@ -14,6 +14,11 @@
  *   versioned_docs/version-<stable>/path/to/page.md       → build/path/to/page.md
  *   versioned_docs/version-<stable>/path/to/dir/index.md  → build/path/to/dir.md
  *
+ * A page's `slug` frontmatter overrides the file path. For example the stable
+ * index.md uses `slug: introduction`, so it maps to build/introduction.md, and
+ * the site root (build/index.md) is left to static/index.md (the agent landing
+ * page served for `Accept: text/markdown` at /).
+ *
  * This lets agents request, e.g.:
  *   https://docs.teku.consensys.io/get-started/install/install-binaries.md
  *
@@ -79,6 +84,45 @@ function addDirective(content) {
   return AGENT_DIRECTIVE + content;
 }
 
+/**
+ * Extract the `slug` frontmatter value, if present, so the output path matches
+ * the page's published URL (Docusaurus honors `slug` over the file path).
+ */
+function getSlug(content) {
+  if (!(content.startsWith("---\n") || content.startsWith("---\r\n"))) {
+    return null;
+  }
+  const closingIdx = content.indexOf("\n---\n", 3);
+  if (closingIdx === -1) {
+    return null;
+  }
+  const frontmatter = content.slice(0, closingIdx);
+  const match = frontmatter.match(/^slug:\s*(.+?)\s*$/m);
+  if (!match) {
+    return null;
+  }
+  return match[1].trim().replace(/^["']|["']$/g, "");
+}
+
+/**
+ * Compute the route path (no leading slash, no extension) for a doc, honoring
+ * `slug` frontmatter. Returns "" for docs that resolve to the site root.
+ */
+function getRoutePath(rel, fileName, slug) {
+  if (slug) {
+    if (slug.startsWith("/")) {
+      return slug.replace(/^\/+/, "");
+    }
+    const dir = path.dirname(rel).split(path.sep).join("/");
+    return dir === "." ? slug : `${dir}/${slug}`;
+  }
+  if (fileName === "index.md") {
+    const parentRel = path.dirname(rel).split(path.sep).join("/");
+    return parentRel === "." ? "" : parentRel;
+  }
+  return rel.split(path.sep).join("/").replace(/\.md$/, "");
+}
+
 function walk(dir, sourceRoot) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const fullPath = path.join(dir, entry.name);
@@ -92,17 +136,18 @@ function walk(dir, sourceRoot) {
         continue;
       }
 
-      let destRel;
-      if (entry.name === "index.md") {
-        const parentRel = path.dirname(rel);
-        destRel = parentRel === "." ? "index.md" : `${parentRel}.md`;
-      } else {
-        destRel = rel;
+      const content = fs.readFileSync(fullPath, "utf8");
+      const routePath = getRoutePath(rel, entry.name, getSlug(content));
+
+      // The site root is reserved for static/index.md (the agent landing page),
+      // so never overwrite build/index.md from the docs tree.
+      if (routePath === "") {
+        skipped++;
+        continue;
       }
 
-      const destPath = path.join(BUILD_DIR, destRel);
+      const destPath = path.join(BUILD_DIR, ...`${routePath}.md`.split("/"));
       fs.mkdirSync(path.dirname(destPath), { recursive: true });
-      const content = fs.readFileSync(fullPath, "utf8");
       fs.writeFileSync(destPath, addDirective(content), "utf8");
       copied++;
     }

--- a/scripts/copy-md-to-build.js
+++ b/scripts/copy-md-to-build.js
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * Post-build script: copy source .md files for the stable docs version into the
+ * build output so that appending ".md" to any documentation URL returns the raw
+ * markdown source.
+ *
+ * doc.teku is versioned. The "stable" version (the one whose label contains
+ * "stable" in versions-preset.json) is served at the site root because it is
+ * set as `lastVersion` in docusaurus.config.js. Its source lives in
+ * `versioned_docs/version-<stable>/`, NOT in `docs/` (which is the development
+ * version served under /development/).
+ *
+ * Docusaurus URL mapping (routeBasePath "/", stable version at root):
+ *   versioned_docs/version-<stable>/path/to/page.md       → build/path/to/page.md
+ *   versioned_docs/version-<stable>/path/to/dir/index.md  → build/path/to/dir.md
+ *
+ * This lets agents request, e.g.:
+ *   https://docs.teku.consensys.io/get-started/install/install-binaries.md
+ *
+ * Only the stable (root) version is covered. The development version and
+ * archived versions are intentionally not exported as raw markdown.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const ROOT_DIR = path.join(__dirname, "..");
+const VERSIONS_PRESET = path.join(ROOT_DIR, "versions-preset.json");
+const VERSIONED_DOCS_DIR = path.join(ROOT_DIR, "versioned_docs");
+const BUILD_DIR = path.join(ROOT_DIR, "build");
+
+// Docusaurus exclude patterns (from docusaurus.config.js)
+const SKIP_PREFIXES = ["_"];
+
+// Directive prepended after frontmatter so agents that fetch .md URLs
+// can discover the documentation index and other markdown pages.
+const AGENT_DIRECTIVE =
+  "> For AI agents: a documentation index is available at " +
+  "[/llms.txt](/llms.txt). " +
+  "Append `.md` to any documentation URL to get the markdown source.\n\n";
+
+let copied = 0;
+let skipped = 0;
+
+function getStableVersion() {
+  const versions = JSON.parse(fs.readFileSync(VERSIONS_PRESET, "utf8"));
+  const stable = Object.keys(versions).find((key) =>
+    versions[key].label.includes("stable")
+  );
+  if (!stable) {
+    throw new Error(
+      "copy-md-to-build: no stable version found in versions-preset.json"
+    );
+  }
+  return stable;
+}
+
+function shouldSkip(relPath) {
+  return relPath
+    .split(path.sep)
+    .some((segment) => SKIP_PREFIXES.some((prefix) => segment.startsWith(prefix)));
+}
+
+/**
+ * Insert the agent directive after the YAML frontmatter block (--- ... ---).
+ * If no frontmatter is present, prepend to the start of the file.
+ */
+function addDirective(content) {
+  // Frontmatter starts at position 0 with "---\n" and ends with "\n---\n"
+  if (content.startsWith("---\n") || content.startsWith("---\r\n")) {
+    const closingIdx = content.indexOf("\n---\n", 3);
+    if (closingIdx !== -1) {
+      const insertAt = closingIdx + 5; // after "\n---\n"
+      return (
+        content.slice(0, insertAt) + "\n" + AGENT_DIRECTIVE + content.slice(insertAt)
+      );
+    }
+  }
+  return AGENT_DIRECTIVE + content;
+}
+
+function walk(dir, sourceRoot) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(fullPath, sourceRoot);
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      const rel = path.relative(sourceRoot, fullPath);
+
+      if (shouldSkip(rel)) {
+        skipped++;
+        continue;
+      }
+
+      let destRel;
+      if (entry.name === "index.md") {
+        const parentRel = path.dirname(rel);
+        destRel = parentRel === "." ? "index.md" : `${parentRel}.md`;
+      } else {
+        destRel = rel;
+      }
+
+      const destPath = path.join(BUILD_DIR, destRel);
+      fs.mkdirSync(path.dirname(destPath), { recursive: true });
+      const content = fs.readFileSync(fullPath, "utf8");
+      fs.writeFileSync(destPath, addDirective(content), "utf8");
+      copied++;
+    }
+  }
+}
+
+const stableVersion = getStableVersion();
+const stableDir = path.join(VERSIONED_DOCS_DIR, `version-${stableVersion}`);
+
+if (!fs.existsSync(stableDir)) {
+  throw new Error(`copy-md-to-build: stable docs directory not found: ${stableDir}`);
+}
+
+walk(stableDir, stableDir);
+console.log(
+  `copy-md-to-build: stable version ${stableVersion} — copied ${copied} files, skipped ${skipped} files`
+);

--- a/src/theme/DocItem/Layout/index.jsx
+++ b/src/theme/DocItem/Layout/index.jsx
@@ -1,0 +1,60 @@
+import React from "react";
+import clsx from "clsx";
+import { useWindowSize } from "@docusaurus/theme-common";
+import { useDoc } from "@docusaurus/plugin-content-docs/client";
+import DocItemPaginator from "@theme/DocItem/Paginator";
+import DocVersionBanner from "@theme/DocVersionBanner";
+import DocVersionBadge from "@theme/DocVersionBadge";
+import DocItemFooter from "@theme/DocItem/Footer";
+import DocItemTOCMobile from "@theme/DocItem/TOC/Mobile";
+import DocItemTOCDesktop from "@theme/DocItem/TOC/Desktop";
+import DocItemContent from "@theme/DocItem/Content";
+import DocBreadcrumbs from "@theme/DocBreadcrumbs";
+import ContentVisibility from "@theme/ContentVisibility";
+import CopyPageButton from "docusaurus-plugin-copy-page-button/src/CopyPageButton";
+import styles from "./styles.module.css";
+/**
+ * Decide if the toc should be rendered, on mobile or desktop viewports
+ */
+function useDocTOC() {
+  const { frontMatter, toc } = useDoc();
+  const windowSize = useWindowSize();
+  const hidden = frontMatter.hide_table_of_contents;
+  const canRender = !hidden && toc.length > 0;
+  const mobile = canRender ? <DocItemTOCMobile /> : undefined;
+  const desktop =
+    canRender && (windowSize === "desktop" || windowSize === "ssr") ? (
+      <DocItemTOCDesktop />
+    ) : undefined;
+  return {
+    hidden,
+    mobile,
+    desktop,
+  };
+}
+export default function DocItemLayout({ children }) {
+  const docTOC = useDocTOC();
+  const { metadata } = useDoc();
+  return (
+    <div className="row">
+      <div className={clsx("col", !docTOC.hidden && styles.docItemCol)}>
+        <ContentVisibility metadata={metadata} />
+        <DocVersionBanner />
+        <div className={styles.docItemContainer}>
+          <article>
+            <div className={styles.docItemHeader}>
+              <DocBreadcrumbs />
+              <CopyPageButton />
+            </div>
+            <DocVersionBadge />
+            {docTOC.mobile}
+            <DocItemContent>{children}</DocItemContent>
+            <DocItemFooter />
+          </article>
+          <DocItemPaginator />
+        </div>
+      </div>
+      {docTOC.desktop && <div className="col col--3">{docTOC.desktop}</div>}
+    </div>
+  );
+}

--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -1,0 +1,29 @@
+.docItemContainer header + *,
+.docItemContainer article > *:first-child {
+  margin-top: 0;
+}
+
+@media (min-width: 997px) {
+  .docItemCol {
+    max-width: 75% !important;
+  }
+}
+
+.docItemHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.docItemHeader > :first-child {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+@media (max-width: 996px) {
+  .docItemHeader {
+    flex-wrap: wrap;
+  }
+}

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,9 +1,27 @@
 import React from "react";
 import AskAiButton from "@site/src/components/AskAiButton";
 
+const agentDirectiveStyle = {
+  position: "absolute",
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: "hidden",
+  clip: "rect(0, 0, 0, 0)",
+  whiteSpace: "nowrap",
+  borderWidth: 0,
+};
+
 export default function Root({ children }) {
   return (
     <>
+      <div style={agentDirectiveStyle}>
+        For AI agents: a documentation index is available at{" "}
+        {/* eslint-disable-next-line @docusaurus/no-html-links */}
+        <a href="/llms.txt">/llms.txt</a>. Markdown versions of pages are
+        available by appending <code>.md</code> to any documentation URL.
+      </div>
       {children}
       <AskAiButton />
     </>

--- a/static/index.md
+++ b/static/index.md
@@ -1,0 +1,40 @@
+# Teku Ethereum consensus client
+
+Teku is an open source Ethereum consensus client developed under the Apache 2.0
+license and written in Java. It contains a full beacon node implementation and a
+validator client for participating in Ethereum proof of stake consensus.
+
+## Get started
+
+Run Teku as a consensus client on Ethereum Mainnet and Ethereum testnets.
+
+- [Teku documentation](https://docs.teku.consensys.io/introduction)
+- [Run Teku from a Docker image](https://docs.teku.consensys.io/get-started/install/run-docker-image)
+- [Install the binary distribution](https://docs.teku.consensys.io/get-started/install/install-binaries)
+- [System requirements](https://docs.teku.consensys.io/get-started/system-requirements)
+
+## Reference
+
+- [Teku command line options](https://docs.teku.consensys.io/reference/cli)
+- [Teku REST API](https://docs.teku.consensys.io/reference/rest)
+
+## What Teku supports
+
+Teku supports running the beacon node synchronization and consensus, proposing
+and attesting to blocks, enterprise-focused metrics using Prometheus, a REST API
+for managing consensus layer node operations, and external key management for
+validator signing keys.
+
+The canonical Teku REST API reference is hosted at
+[consensys.github.io/teku](https://consensys.github.io/teku/).
+
+## Agent-readable resources
+
+- [llms.txt](https://docs.teku.consensys.io/llms.txt) lists the main documentation pages.
+- [llms-full.txt](https://docs.teku.consensys.io/llms-full.txt) contains the full documentation corpus in one Markdown file.
+- [sitemap.xml](https://docs.teku.consensys.io/sitemap.xml) lists the published site URLs.
+
+## Questions
+
+For questions about Teku, ask on the Consensys Discord or open an issue in the
+[Teku repository](https://github.com/Consensys/teku).

--- a/vercel.json
+++ b/vercel.json
@@ -91,7 +91,7 @@
       "destination": "/index.md"
     },
     {
-      "source": "/:path+",
+      "source": "/:path((?!.*\\.).*)",
       "has": [
         {
           "type": "header",
@@ -99,7 +99,7 @@
           "value": ".*text/markdown.*"
         }
       ],
-      "destination": "/:path+.md"
+      "destination": "/:path.md"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,41 @@
 {
   "cleanUrls": true,
+  "headers": [
+    {
+      "source": "/",
+      "headers": [
+        {
+          "key": "Link",
+          "value": "</sitemap.xml>; rel=\"sitemap\"; type=\"application/xml\", </llms.txt>; rel=\"describedby\"; type=\"text/plain\", </llms-full.txt>; rel=\"describedby\"; type=\"text/plain\""
+        }
+      ]
+    },
+    {
+      "source": "/",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/markdown.*"
+        }
+      ],
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "text/markdown; charset=utf-8"
+        }
+      ]
+    },
+    {
+      "source": "/(.*)\\.md",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "text/markdown; charset=utf-8"
+        }
+      ]
+    }
+  ],
   "redirects": [
     {
       "source": "/en/latest",
@@ -40,6 +76,30 @@
       "source": "/:path(\\d*\\.\\d*\\.\\d*)",
       "destination": "/:path*/introduction",
       "permanent": true
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/markdown.*"
+        }
+      ],
+      "destination": "/index.md"
+    },
+    {
+      "source": "/:path+",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/markdown.*"
+        }
+      ],
+      "destination": "/:path+.md"
     }
   ]
 }

--- a/versioned_docs/version-26.2.0/get-started/start-teku.md
+++ b/versioned_docs/version-26.2.0/get-started/start-teku.md
@@ -76,8 +76,8 @@ You can specify [`--rest-api-host-allowlist`](../reference/cli/index.md#rest-api
 
 To run a validator, connect to a [running beacon node].
 
-Use the [`validator-client`](../reference/cli/subcommands/validator-client.md#validator-client-vc) or
-[`vc`](../reference/cli/subcommands/validator-client.md#validator-client-vc) subcommand to run a Teku as a validator.
+Use the [`validator-client`](../reference/cli/subcommands/validator-client.md) or
+[`vc`](../reference/cli/subcommands/validator-client.md) subcommand to run a Teku as a validator.
 
 ```title="Example"
 teku validator-client \

--- a/versioned_docs/version-26.2.0/how-to/prevent-slashing/detect-doppelgangers.md
+++ b/versioned_docs/version-26.2.0/how-to/prevent-slashing/detect-doppelgangers.md
@@ -9,7 +9,7 @@ Doppelganger detection checks if the validators' keys are already active before 
 
 When enabled, doppelganger detection is triggered from two entry points:
 
-1. At [validator client startup](../../get-started/start-teku.md#start-teku): If at least one
+1. At [validator client startup](../../get-started/start-teku.md): If at least one
     doppelganger is detected, the Teku validator client shuts down after it finishes the check with
     exit code `2`.
     When this happens, you should not restart Teku by default because validators will likely be slashed.

--- a/versioned_docs/version-26.3.0/get-started/start-teku.md
+++ b/versioned_docs/version-26.3.0/get-started/start-teku.md
@@ -76,8 +76,8 @@ You can specify [`--rest-api-host-allowlist`](../reference/cli/index.md#rest-api
 
 To run a validator, connect to a [running beacon node].
 
-Use the [`validator-client`](../reference/cli/subcommands/validator-client.md#validator-client-vc) or
-[`vc`](../reference/cli/subcommands/validator-client.md#validator-client-vc) subcommand to run a Teku as a validator.
+Use the [`validator-client`](../reference/cli/subcommands/validator-client.md) or
+[`vc`](../reference/cli/subcommands/validator-client.md) subcommand to run a Teku as a validator.
 
 ```title="Example"
 teku validator-client \

--- a/versioned_docs/version-26.3.0/how-to/prevent-slashing/detect-doppelgangers.md
+++ b/versioned_docs/version-26.3.0/how-to/prevent-slashing/detect-doppelgangers.md
@@ -9,7 +9,7 @@ Doppelganger detection checks if the validators' keys are already active before 
 
 When enabled, doppelganger detection is triggered from two entry points:
 
-1. At [validator client startup](../../get-started/start-teku.md#start-teku): If at least one
+1. At [validator client startup](../../get-started/start-teku.md): If at least one
     doppelganger is detected, the Teku validator client shuts down after it finishes the check with
     exit code `2`.
     When this happens, you should not restart Teku by default because validators will likely be slashed.

--- a/versioned_docs/version-26.4.0/get-started/start-teku.md
+++ b/versioned_docs/version-26.4.0/get-started/start-teku.md
@@ -76,8 +76,8 @@ You can specify [`--rest-api-host-allowlist`](../reference/cli/index.md#rest-api
 
 To run a validator, connect to a [running beacon node].
 
-Use the [`validator-client`](../reference/cli/subcommands/validator-client.md#validator-client-vc) or
-[`vc`](../reference/cli/subcommands/validator-client.md#validator-client-vc) subcommand to run a Teku as a validator.
+Use the [`validator-client`](../reference/cli/subcommands/validator-client.md) or
+[`vc`](../reference/cli/subcommands/validator-client.md) subcommand to run a Teku as a validator.
 
 ```title="Example"
 teku validator-client \

--- a/versioned_docs/version-26.4.0/how-to/prevent-slashing/detect-doppelgangers.md
+++ b/versioned_docs/version-26.4.0/how-to/prevent-slashing/detect-doppelgangers.md
@@ -9,7 +9,7 @@ Doppelganger detection checks if the validators' keys are already active before 
 
 When enabled, doppelganger detection is triggered from two entry points:
 
-1. At [validator client startup](../../get-started/start-teku.md#start-teku): If at least one
+1. At [validator client startup](../../get-started/start-teku.md): If at least one
     doppelganger is detected, the Teku validator client shuts down after it finishes the check with
     exit code `2`.
     When this happens, you should not restart Teku by default because validators will likely be slashed.

--- a/versioned_docs/version-26.6.0/get-started/start-teku.md
+++ b/versioned_docs/version-26.6.0/get-started/start-teku.md
@@ -76,8 +76,8 @@ You can specify [`--rest-api-host-allowlist`](../reference/cli/index.md#rest-api
 
 To run a validator, connect to a [running beacon node].
 
-Use the [`validator-client`](../reference/cli/subcommands/validator-client.md#validator-client-vc) or
-[`vc`](../reference/cli/subcommands/validator-client.md#validator-client-vc) subcommand to run a Teku as a validator.
+Use the [`validator-client`](../reference/cli/subcommands/validator-client.md) or
+[`vc`](../reference/cli/subcommands/validator-client.md) subcommand to run a Teku as a validator.
 
 ```title="Example"
 teku validator-client \

--- a/versioned_docs/version-26.6.0/how-to/prevent-slashing/detect-doppelgangers.md
+++ b/versioned_docs/version-26.6.0/how-to/prevent-slashing/detect-doppelgangers.md
@@ -9,7 +9,7 @@ Doppelganger detection checks if the validators' keys are already active before 
 
 When enabled, doppelganger detection is triggered from two entry points:
 
-1. At [validator client startup](../../get-started/start-teku.md#start-teku): If at least one
+1. At [validator client startup](../../get-started/start-teku.md): If at least one
     doppelganger is detected, the Teku validator client shuts down after it finishes the check with
     exit code `2`.
     When this happens, you should not restart Teku by default because validators will likely be slashed.

--- a/versioned_docs/version-26.6.1/get-started/start-teku.md
+++ b/versioned_docs/version-26.6.1/get-started/start-teku.md
@@ -76,8 +76,8 @@ You can specify [`--rest-api-host-allowlist`](../reference/cli/index.md#rest-api
 
 To run a validator, connect to a [running beacon node].
 
-Use the [`validator-client`](../reference/cli/subcommands/validator-client.md#validator-client-vc) or
-[`vc`](../reference/cli/subcommands/validator-client.md#validator-client-vc) subcommand to run a Teku as a validator.
+Use the [`validator-client`](../reference/cli/subcommands/validator-client.md) or
+[`vc`](../reference/cli/subcommands/validator-client.md) subcommand to run a Teku as a validator.
 
 ```title="Example"
 teku validator-client \

--- a/versioned_docs/version-26.6.1/how-to/prevent-slashing/detect-doppelgangers.md
+++ b/versioned_docs/version-26.6.1/how-to/prevent-slashing/detect-doppelgangers.md
@@ -9,7 +9,7 @@ Doppelganger detection checks if the validators' keys are already active before 
 
 When enabled, doppelganger detection is triggered from two entry points:
 
-1. At [validator client startup](../../get-started/start-teku.md#start-teku): If at least one
+1. At [validator client startup](../../get-started/start-teku.md): If at least one
     doppelganger is detected, the Teku validator client shuts down after it finishes the check with
     exit code `2`.
     When this happens, you should not restart Teku by default because validators will likely be slashed.


### PR DESCRIPTION
## Summary

Brings the Teku docs site up to the Consensys agent-readiness standard (matching besu-docs and docs-template) so AI agents and LLM tools can discover, read, and cite the documentation. Also includes build/link fixes surfaced while validating the change.

Preview: https://doc-teku-tut7e2da5-consensys-ddffed67.vercel.app

Fixes #748 

Changes include:

- **Raw Markdown at `.md` URLs** – new `scripts/copy-md-to-build.js` (chained into `npm run build`) exports the stable (root) version's Markdown so appending `.md` to any root doc URL returns its source. It is version- and `slug`-aware, and reserves `build/index.md` for the agent landing page.
- **Copy page button** – `docusaurus-plugin-copy-page-button` via a swizzled `src/theme/DocItem/Layout` (copy as Markdown / open in an AI assistant).
- **Content negotiation** – `vercel.json` `headers` and `rewrites` advertise `llms.txt`/`sitemap.xml` and serve Markdown for `Accept: text/markdown`.
- **Hidden agent directive** – screen-reader-hidden "For AI agents" pointer to `/llms.txt` in `src/theme/Root.js`.
- **Agent landing page** – `static/index.md` served at the root for `Accept: text/markdown`.
- **Broken anchors** – removed `#validator-client-vc` and `#start-teku` fragments
  from links in `get-started/start-teku.md` and `how-to/prevent-slashing/detect-doppelgangers.md`. Both pointed at a page's own title H1, which Docusaurus doesn't register as a linkable anchor. Fixed in the
  current docs and all five versioned snapshots.
- **Link checker false positives** – `.linkspector.yml` now ignores root-absolute `/img/` static asset paths, which Docusaurus resolves correctly but linkspector reported as 404s.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation site, build, and deployment configuration only; no runtime Teku product or security-sensitive application logic.
> 
> **Overview**
> Aligns the Teku docs site with the Consensys agent-readiness pattern so LLMs can discover and fetch documentation reliably.
> 
> **Agent-facing delivery:** `npm run build` now runs `scripts/copy-md-to-build.js`, which mirrors stable (root) version Markdown into `build/` with slug-aware paths and an agent pointer to `/llms.txt`. `vercel.json` adds `Link` headers for `sitemap.xml` / `llms.txt` and rewrites plus `Content-Type` for `Accept: text/markdown` (root → `static/index.md`, doc paths → `*.md`). A swizzled `DocItem/Layout` adds **Copy page** via `docusaurus-plugin-copy-page-button`; `Root.js` adds a hidden “For AI agents” note. `AGENTS.md` documents the setup.
> 
> **Build and hygiene:** `showLastUpdateTime` is turned off in `docusaurus.config.js` to avoid Vercel builds failing without git history. `.linkspector.yml` ignores `/img/` paths. Internal links drop broken `#validator-client-vc` and `#start-teku` fragments in current docs and versioned snapshots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7ee3a494143a837b11feaa31a74a45343133728. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->