### PR TITLE
Update Discord links to new Teku server

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Consensys
-    url: https://discord.com/invite/consensys
-    about: Discuss with the Consensys community
+  - name: Teku Discord
+    url: https://discord.gg/teku
+    about: Discuss with the Teku community

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -16,4 +16,4 @@ The validator client performs [validator duties](proof-of-stake.md).
 
 You can [run the beacon node only](../get-started/start-teku.md#start-the-beacon-node), or [run the beacon node and validator client](../get-started/start-teku.md#start-the-clients-in-a-single-process).
 
-Read more about the [Ethereum consensus client architecture](https://ethereum.org/en/developers/docs/nodes-and-clients/). For more information about the Teku architecture, contact us on [Teku Discord channel](https://discord.com/invite/consensys).
+Read more about the [Ethereum consensus client architecture](https://ethereum.org/en/developers/docs/nodes-and-clients/). For more information about the Teku architecture, contact us on [Teku Discord channel](https://discord.gg/teku).

--- a/docs/how-to/migrate-database.md
+++ b/docs/how-to/migrate-database.md
@@ -99,4 +99,4 @@ Teku creates a RocksDB database, and starts from the specified recent state. Tek
 [`prune` mode]: ../reference/cli/index.md#data-storage-mode
 [`archive` mode]: ../reference/cli/index.md#data-storage-mode
 [Start Teku from a recent state]: ../get-started/checkpoint-start.md
-[Teku Discord channel]: https://discord.com/invite/consensys
+[Teku Discord channel]: https://discord.gg/teku

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -142,7 +142,7 @@ const config = {
             position: "right",
           },
           {
-            href: "https://discord.com/invite/consensys",
+            href: "https://discord.gg/teku",
             className: "header-discord-link",
             position: "right",
           },
@@ -194,8 +194,8 @@ const config = {
             title: "Community",
             items: [
               {
-                label: "ConsenSys Discord",
-                href: "https://discord.com/invite/consensys",
+                label: "Teku Discord",
+                href: "https://discord.gg/teku",
               },
               {
                 label: "Teku GitHub",

--- a/static/index.md
+++ b/static/index.md
@@ -36,5 +36,5 @@ The canonical Teku REST API reference is hosted at
 
 ## Questions
 
-For questions about Teku, ask on the Consensys Discord or open an issue in the
+For questions about Teku, ask on the [Teku Discord](https://discord.gg/teku) or open an issue in the
 [Teku repository](https://github.com/Consensys/teku).

--- a/versioned_docs/version-26.2.0/concepts/architecture.md
+++ b/versioned_docs/version-26.2.0/concepts/architecture.md
@@ -16,4 +16,4 @@ The validator client performs [validator duties](proof-of-stake.md).
 
 You can [run the beacon node only](../get-started/start-teku.md#start-the-beacon-node), or [run the beacon node and validator client](../get-started/start-teku.md#start-the-clients-in-a-single-process).
 
-Read more about the [Ethereum consensus client architecture](https://ethereum.org/en/developers/docs/nodes-and-clients/). For more information about the Teku architecture, contact us on [Teku Discord channel](https://discord.com/invite/consensys).
+Read more about the [Ethereum consensus client architecture](https://ethereum.org/en/developers/docs/nodes-and-clients/). For more information about the Teku architecture, contact us on [Teku Discord channel](https://discord.gg/teku).

--- a/versioned_docs/version-26.2.0/how-to/migrate-database.md
+++ b/versioned_docs/version-26.2.0/how-to/migrate-database.md
@@ -106,4 +106,4 @@ Teku creates a LevelDB2 database, and starts from the specified recent state. Te
 [`prune` mode]: ../reference/cli/index.md#data-storage-mode
 [`archive` mode]: ../reference/cli/index.md#data-storage-mode
 [supply the finalized checkpoint state]: ../get-started/checkpoint-start.md
-[Teku Discord channel]: https://discord.com/invite/consensys
+[Teku Discord channel]: https://discord.gg/teku

--- a/versioned_docs/version-26.3.0/concepts/architecture.md
+++ b/versioned_docs/version-26.3.0/concepts/architecture.md
@@ -16,4 +16,4 @@ The validator client performs [validator duties](proof-of-stake.md).
 
 You can [run the beacon node only](../get-started/start-teku.md#start-the-beacon-node), or [run the beacon node and validator client](../get-started/start-teku.md#start-the-clients-in-a-single-process).
 
-Read more about the [Ethereum consensus client architecture](https://ethereum.org/en/developers/docs/nodes-and-clients/). For more information about the Teku architecture, contact us on [Teku Discord channel](https://discord.com/invite/consensys).
+Read more about the [Ethereum consensus client architecture](https://ethereum.org/en/developers/docs/nodes-and-clients/). For more information about the Teku architecture, contact us on [Teku Discord channel](https://discord.gg/teku).

--- a/versioned_docs/version-26.3.0/how-to/migrate-database.md
+++ b/versioned_docs/version-26.3.0/how-to/migrate-database.md
@@ -109,4 +109,4 @@ Teku creates a LevelDB2 database, and starts from the specified recent state. Te
 [`prune` mode]: ../reference/cli/index.md#data-storage-mode
 [`archive` mode]: ../reference/cli/index.md#data-storage-mode
 [supply the finalized checkpoint state]: ../get-started/checkpoint-start.md
-[Teku Discord channel]: https://discord.com/invite/consensys
+[Teku Discord channel]: https://discord.gg/teku

--- a/versioned_docs/version-26.4.0/concepts/architecture.md
+++ b/versioned_docs/version-26.4.0/concepts/architecture.md
@@ -16,4 +16,4 @@ The validator client performs [validator duties](proof-of-stake.md).
 
 You can [run the beacon node only](../get-started/start-teku.md#start-the-beacon-node), or [run the beacon node and validator client](../get-started/start-teku.md#start-the-clients-in-a-single-process).
 
-Read more about the [Ethereum consensus client architecture](https://ethereum.org/en/developers/docs/nodes-and-clients/). For more information about the Teku architecture, contact us on [Teku Discord channel](https://discord.com/invite/consensys).
+Read more about the [Ethereum consensus client architecture](https://ethereum.org/en/developers/docs/nodes-and-clients/). For more information about the Teku architecture, contact us on [Teku Discord channel](https://discord.gg/teku).

--- a/versioned_docs/version-26.4.0/how-to/migrate-database.md
+++ b/versioned_docs/version-26.4.0/how-to/migrate-database.md
@@ -99,4 +99,4 @@ Teku creates a RocksDB database, and starts from the specified recent state. Tek
 [`prune` mode]: ../reference/cli/index.md#data-storage-mode
 [`archive` mode]: ../reference/cli/index.md#data-storage-mode
 [Start Teku from a recent state]: ../get-started/checkpoint-start.md
-[Teku Discord channel]: https://discord.com/invite/consensys
+[Teku Discord channel]: https://discord.gg/teku

--- a/versioned_docs/version-26.6.0/concepts/architecture.md
+++ b/versioned_docs/version-26.6.0/concepts/architecture.md
@@ -16,4 +16,4 @@ The validator client performs [validator duties](proof-of-stake.md).
 
 You can [run the beacon node only](../get-started/start-teku.md#start-the-beacon-node), or [run the beacon node and validator client](../get-started/start-teku.md#start-the-clients-in-a-single-process).
 
-Read more about the [Ethereum consensus client architecture](https://ethereum.org/en/developers/docs/nodes-and-clients/). For more information about the Teku architecture, contact us on [Teku Discord channel](https://discord.com/invite/consensys).
+Read more about the [Ethereum consensus client architecture](https://ethereum.org/en/developers/docs/nodes-and-clients/). For more information about the Teku architecture, contact us on [Teku Discord channel](https://discord.gg/teku).

--- a/versioned_docs/version-26.6.0/how-to/migrate-database.md
+++ b/versioned_docs/version-26.6.0/how-to/migrate-database.md
@@ -99,4 +99,4 @@ Teku creates a RocksDB database, and starts from the specified recent state. Tek
 [`prune` mode]: ../reference/cli/index.md#data-storage-mode
 [`archive` mode]: ../reference/cli/index.md#data-storage-mode
 [Start Teku from a recent state]: ../get-started/checkpoint-start.md
-[Teku Discord channel]: https://discord.com/invite/consensys
+[Teku Discord channel]: https://discord.gg/teku

--- a/versioned_docs/version-26.6.1/concepts/architecture.md
+++ b/versioned_docs/version-26.6.1/concepts/architecture.md
@@ -16,4 +16,4 @@ The validator client performs [validator duties](proof-of-stake.md).
 
 You can [run the beacon node only](../get-started/start-teku.md#start-the-beacon-node), or [run the beacon node and validator client](../get-started/start-teku.md#start-the-clients-in-a-single-process).
 
-Read more about the [Ethereum consensus client architecture](https://ethereum.org/en/developers/docs/nodes-and-clients/). For more information about the Teku architecture, contact us on [Teku Discord channel](https://discord.com/invite/consensys).
+Read more about the [Ethereum consensus client architecture](https://ethereum.org/en/developers/docs/nodes-and-clients/). For more information about the Teku architecture, contact us on [Teku Discord channel](https://discord.gg/teku).

--- a/versioned_docs/version-26.6.1/how-to/migrate-database.md
+++ b/versioned_docs/version-26.6.1/how-to/migrate-database.md
@@ -99,4 +99,4 @@ Teku creates a RocksDB database, and starts from the specified recent state. Tek
 [`prune` mode]: ../reference/cli/index.md#data-storage-mode
 [`archive` mode]: ../reference/cli/index.md#data-storage-mode
 [Start Teku from a recent state]: ../get-started/checkpoint-start.md
-[Teku Discord channel]: https://discord.com/invite/consensys
+[Teku Discord channel]: https://discord.gg/teku


### PR DESCRIPTION
## Summary
- Replace old Consensys Discord invite (`discord.com/invite/consensys`) with new Teku Discord server (`https://discord.gg/teku`)
- Updated labels/text from "Consensys Discord" → "Teku Discord" where they now point to the Teku server

## Files
- `docs/` — `concepts/architecture.md`, `how-to/migrate-database.md`
- `versioned_docs/` — same two files across 26.2.0, 26.3.0, 26.4.0, 26.6.0, 26.6.1
- `docusaurus.config.js` — navbar Discord link + footer link/label
- `static/index.md` — linked "Teku Discord"
- `.github/ISSUE_TEMPLATE/config.yml` — contact link + name/about

## Left untouched
- `discord.gg/ethstaker` in `testnet.md` — different community (faucet help)
- `build/` + `.docusaurus/` — generated artifacts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and link-only changes with no application logic or security impact.
> 
> **Overview**
> Community and support links across the Teku documentation site now use the **Teku Discord** invite (`https://discord.gg/teku`) instead of the old **Consensys Discord** URL.
> 
> **`docusaurus.config.js`** updates the navbar Discord icon and the footer **Community** entry (label changed from ConsenSys Discord to Teku Discord). **`.github/ISSUE_TEMPLATE/config.yml`** replaces the Consensys contact link with a Teku Discord entry and matching name/about text.
> 
> Current and **versioned** docs (`architecture.md`, `migrate-database.md` for 26.2.0–26.6.1) and **`static/index.md`** refresh inline links and reference definitions so readers and migration troubleshooting point at the Teku server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e401118543f1e4928e0e4214e499d7fec9048905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->